### PR TITLE
cargo: add repository metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "paseto"
 description = "An alternative token format to JWT"
 version = "1.0.5"
+repository = "https://github.com/instructure/paseto"
 license = "MIT"
 authors = [
   "Cynthia Coan <ccoan@instructure.com>"


### PR DESCRIPTION
This adds a "repository" field to cargo manifest, making it easier
for casual readers to find the repository directly from crates.io
page.