### PR TITLE
allow validating a token with only a public key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Use newer github actions.
 * Remove Azure Pipelines.
+* Allow TokenBuilder to just need a public key for validation.
+* Make JSON Payload Validation public so anyone can use it.
 
 ## 1.0.5
 


### PR DESCRIPTION
## Motivation ##

This allows a user to use the "nicer" token interface (which actually validates the known JWT fields, exp, iat, nbf) with only a public key in the validation phase. This is already possible seeing as how the raw interface the token interface builds on supports this.

Secondly I also decided to make the validate_potential_json_blob function public. There isn't a real reason it needed to be private, and if a user just wants the validation of those fields they should be able to have it.

## Test Plan ##

All code has automated tests, and all tests continue to pass
