### PR TITLE
Convert parameter passing from value to reference for token procedures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 * Remove `mut` from the keys used by v2/local.rs.
+* Switch to taking messages, footers, and keys by reference.
 
 ## 1.0.6
 

--- a/examples/direct-protocol.rs
+++ b/examples/direct-protocol.rs
@@ -5,30 +5,29 @@ fn main() {
   let footer = String::from("key-id:gandalf0");
 
   // Version 1
-  let v1_token =
-    paseto::v1::local::local_paseto(message.clone(), None, key).expect("Failed to encrypt V1 Token sans footer.");
+  let v1_token = paseto::v1::local::local_paseto(&message, None, key).expect("Failed to encrypt V1 Token sans footer.");
   println!("{:?}", v1_token);
   let decrypted_v1_token =
-    paseto::v1::local::decrypt_paseto(v1_token, None, key).expect("Failed to decrypt V1 Token sans footer.");
+    paseto::v1::local::decrypt_paseto(&v1_token, None, key).expect("Failed to decrypt V1 Token sans footer.");
   println!("{:?}", decrypted_v1_token);
   let v1_footer_token =
-    paseto::v1::local::local_paseto(message.clone(), Some(footer.clone()), key).expect("Failed to encrypt V1 Token.");
+    paseto::v1::local::local_paseto(&message, Some(footer.clone()), key).expect("Failed to encrypt V1 Token.");
   println!("{:?}", v1_footer_token);
-  let decrypted_v1_footer_token =
-    paseto::v1::local::decrypt_paseto(v1_footer_token, Some(footer.clone()), key).expect("Failed to decrypt V1 Token.");
+  let decrypted_v1_footer_token = paseto::v1::local::decrypt_paseto(&v1_footer_token, Some(footer.clone()), key)
+    .expect("Failed to decrypt V1 Token.");
   println!("{:?}", decrypted_v1_footer_token);
 
   // Version 2
-  let v2_token = paseto::v2::local::local_paseto(message.clone(), None, &mut key_mut)
-    .expect("Failed to encrypt V2 Token sans footer.");
+  let v2_token =
+    paseto::v2::local::local_paseto(&message, None, &mut key_mut).expect("Failed to encrypt V2 Token sans footer.");
   println!("{:?}", v2_token);
   let decrypted_v2_token =
-    paseto::v2::local::decrypt_paseto(v2_token, None, &mut key_mut).expect("Failed to decrypt V2 Token sans footer.");
+    paseto::v2::local::decrypt_paseto(&v2_token, None, &mut key_mut).expect("Failed to decrypt V2 Token sans footer.");
   println!("{:?}", decrypted_v2_token);
   let v2_footer_token =
-    paseto::v2::local::local_paseto(message, Some(footer.clone()), &mut key_mut).expect("Failed to encrypt V2 Token.");
+    paseto::v2::local::local_paseto(&message, Some(footer.clone()), &mut key_mut).expect("Failed to encrypt V2 Token.");
   println!("{:?}", v2_footer_token);
-  let decrypted_v2_footer = paseto::v2::local::decrypt_paseto(v2_footer_token, Some(footer), &mut key_mut)
+  let decrypted_v2_footer = paseto::v2::local::decrypt_paseto(&v2_footer_token, Some(footer), &mut key_mut)
     .expect("Failed to decrypt V2 Token.");
   println!("{:?}", decrypted_v2_footer);
 }

--- a/examples/direct-protocol.rs
+++ b/examples/direct-protocol.rs
@@ -11,10 +11,10 @@ fn main() {
     paseto::v1::local::decrypt_paseto(&v1_token, None, key).expect("Failed to decrypt V1 Token sans footer.");
   println!("{:?}", decrypted_v1_token);
   let v1_footer_token =
-    paseto::v1::local::local_paseto(&message, Some(footer.clone()), key).expect("Failed to encrypt V1 Token.");
+    paseto::v1::local::local_paseto(&message, Some(&footer), key).expect("Failed to encrypt V1 Token.");
   println!("{:?}", v1_footer_token);
-  let decrypted_v1_footer_token = paseto::v1::local::decrypt_paseto(&v1_footer_token, Some(footer.clone()), key)
-    .expect("Failed to decrypt V1 Token.");
+  let decrypted_v1_footer_token =
+    paseto::v1::local::decrypt_paseto(&v1_footer_token, Some(&footer), key).expect("Failed to decrypt V1 Token.");
   println!("{:?}", decrypted_v1_footer_token);
 
   // Version 2
@@ -25,9 +25,9 @@ fn main() {
     paseto::v2::local::decrypt_paseto(&v2_token, None, &mut key_mut).expect("Failed to decrypt V2 Token sans footer.");
   println!("{:?}", decrypted_v2_token);
   let v2_footer_token =
-    paseto::v2::local::local_paseto(&message, Some(footer.clone()), &mut key_mut).expect("Failed to encrypt V2 Token.");
+    paseto::v2::local::local_paseto(&message, Some(&footer), &mut key_mut).expect("Failed to encrypt V2 Token.");
   println!("{:?}", v2_footer_token);
-  let decrypted_v2_footer = paseto::v2::local::decrypt_paseto(&v2_footer_token, Some(footer), &mut key_mut)
+  let decrypted_v2_footer = paseto::v2::local::decrypt_paseto(&v2_footer_token, Some(&footer), &mut key_mut)
     .expect("Failed to decrypt V2 Token.");
   println!("{:?}", decrypted_v2_footer);
 }

--- a/examples/local-using-builders.rs
+++ b/examples/local-using-builders.rs
@@ -22,7 +22,7 @@ fn main() {
 
   let verified_token = paseto::tokens::validate_local_token(
     &token,
-    Some(String::from("key-id:gandalf0")),
+    Some("key-id:gandalf0"),
     Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
   )
   .expect("Failed to validate token!");

--- a/examples/local-using-builders.rs
+++ b/examples/local-using-builders.rs
@@ -21,7 +21,7 @@ fn main() {
   println!("{:?}", token);
 
   let verified_token = paseto::tokens::validate_local_token(
-    token,
+    &token,
     Some(String::from("key-id:gandalf0")),
     Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
   )

--- a/examples/public-using-builder.rs
+++ b/examples/public-using-builder.rs
@@ -28,9 +28,9 @@ fn main() {
   println!("{:?}", token);
 
   let verified_token = paseto::tokens::validate_public_token(
-    token,
+    &token,
     Some(String::from("key-id:gandalf0")),
-    paseto::tokens::PasetoPublicKey::ED25519KeyPair(cloned_key),
+    &paseto::tokens::PasetoPublicKey::ED25519KeyPair(cloned_key),
   )
   .expect("Failed to validate token!");
   println!("{:?}", verified_token);

--- a/examples/public-using-builder.rs
+++ b/examples/public-using-builder.rs
@@ -29,7 +29,7 @@ fn main() {
 
   let verified_token = paseto::tokens::validate_public_token(
     &token,
-    Some(String::from("key-id:gandalf0")),
+    Some("key-id:gandalf0"),
     &paseto::tokens::PasetoPublicKey::ED25519KeyPair(cloned_key),
   )
   .expect("Failed to validate token!");

--- a/src/tokens/builder.rs
+++ b/src/tokens/builder.rs
@@ -52,10 +52,10 @@ impl PasetoBuilder {
 
     if self.encryption_key.is_some() {
       let mut enc_key = self.encryption_key.unwrap();
-      return V2Local(strd_msg, self.footer, &mut enc_key);
+      return V2Local(&strd_msg, self.footer, &mut enc_key);
     } else if self.ed_key.is_some() {
       let ed_key_pair = self.ed_key.unwrap();
-      return V2Public(strd_msg, self.footer, &ed_key_pair);
+      return V2Public(&strd_msg, self.footer, &ed_key_pair);
     } else if self.rsa_key.is_some() {
       let the_rsa_key = self.rsa_key.unwrap();
       let key_pair = RsaKeyPair::from_der(&the_rsa_key);
@@ -63,7 +63,7 @@ impl PasetoBuilder {
         return Err(RsaKeyErrors::InvalidKey {})?;
       }
       let mut key_pair = key_pair.unwrap();
-      return V1Public(strd_msg, self.footer, &mut key_pair);
+      return V1Public(&strd_msg, self.footer, &mut key_pair);
     } else {
       return Err(GenericError::NoKeyProvided {})?;
     }
@@ -121,10 +121,10 @@ impl PasetoBuilder {
 
     if self.encryption_key.is_some() {
       let mut enc_key = self.encryption_key.unwrap();
-      return V2Local(strd_msg, self.footer, &mut enc_key);
+      return V2Local(&strd_msg, self.footer, &mut enc_key);
     } else if self.ed_key.is_some() {
       let ed_key_pair = self.ed_key.unwrap();
-      return V2Public(strd_msg, self.footer, &ed_key_pair);
+      return V2Public(&strd_msg, self.footer, &ed_key_pair);
     } else {
       return Err(GenericError::NoKeyProvided {})?;
     }
@@ -236,7 +236,7 @@ mod unit_test {
       .expect("Failed to construct paseto token w/ builder!");
 
     let decrypted_token = V2Decrypt(
-      token,
+      &token,
       Some(String::from("footer")),
       &mut Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
     )

--- a/src/tokens/builder.rs
+++ b/src/tokens/builder.rs
@@ -52,10 +52,10 @@ impl PasetoBuilder {
 
     if self.encryption_key.is_some() {
       let mut enc_key = self.encryption_key.unwrap();
-      return V2Local(&strd_msg, self.footer, &mut enc_key);
+      return V2Local(&strd_msg, self.footer.as_deref(), &mut enc_key);
     } else if self.ed_key.is_some() {
       let ed_key_pair = self.ed_key.unwrap();
-      return V2Public(&strd_msg, self.footer, &ed_key_pair);
+      return V2Public(&strd_msg, self.footer.as_deref(), &ed_key_pair);
     } else if self.rsa_key.is_some() {
       let the_rsa_key = self.rsa_key.unwrap();
       let key_pair = RsaKeyPair::from_der(&the_rsa_key);
@@ -63,7 +63,7 @@ impl PasetoBuilder {
         return Err(RsaKeyErrors::InvalidKey {})?;
       }
       let mut key_pair = key_pair.unwrap();
-      return V1Public(&strd_msg, self.footer, &mut key_pair);
+      return V1Public(&strd_msg, self.footer.as_deref(), &mut key_pair);
     } else {
       return Err(GenericError::NoKeyProvided {})?;
     }
@@ -237,7 +237,7 @@ mod unit_test {
 
     let decrypted_token = V2Decrypt(
       &token,
-      Some(String::from("footer")),
+      Some("footer"),
       &mut Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
     )
     .expect("Failed to decrypt token constructed with builder!");

--- a/src/tokens/builder.rs
+++ b/src/tokens/builder.rs
@@ -25,7 +25,7 @@ pub struct PasetoBuilder {
   encryption_key: Option<Vec<u8>>,
   /// The RSA Key pairs in DER format, for V1 Public Tokens.
   #[cfg(feature = "v1")]
-  rsa_key: Option<(Vec<u8>)>,
+  rsa_key: Option<Vec<u8>>,
   /// The ED25519 Key Pair, for V2 Public Tokens.
   #[cfg(feature = "v2")]
   ed_key: Option<Ed25519KeyPair>,

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -40,8 +40,8 @@ pub enum PasetoPublicKey {
 ///   * jti
 ///   * issuedBy
 ///   * subject
-pub fn validate_potential_json_blob(data: String) -> Result<JsonValue, Error> {
-  let value: JsonValue = ParseJson(&data)?;
+pub fn validate_potential_json_blob(data: &str) -> Result<JsonValue, Error> {
+  let value: JsonValue = ParseJson(data)?;
 
   let validation = {
     let issued_at_opt = value.get("iat");
@@ -114,13 +114,13 @@ pub fn validate_potential_json_blob(data: String) -> Result<JsonValue, Error> {
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
 #[cfg(all(feature = "v1", feature = "v2"))]
-pub fn validate_local_token(token: String, footer: Option<String>, key: Vec<u8>) -> Result<JsonValue, Error> {
+pub fn validate_local_token(token: &str, footer: Option<String>, key: Vec<u8>) -> Result<JsonValue, Error> {
   if token.starts_with("v2.local.") {
-    let token = V2Decrypt(token, footer, &key)?;
-    return validate_potential_json_blob(token);
+    let message = V2Decrypt(token, footer, &key)?;
+    return validate_potential_json_blob(&message);
   } else if token.starts_with("v1.local.") {
-    let token = V1Decrypt(token, footer, &key)?;
-    return validate_potential_json_blob(token);
+    let message = V1Decrypt(token, footer, &key)?;
+    return validate_potential_json_blob(&message);
   }
 
   return Err(GenericError::InvalidToken {})?;
@@ -140,8 +140,8 @@ pub fn validate_local_token(token: String, footer: Option<String>, key: Vec<u8>)
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
 #[cfg(all(feature = "v1", not(feature = "v2")))]
-pub fn validate_local_token(token: String, footer: Option<String>, key: Vec<u8>) -> Result<Jsonvalue, Error> {
-  let token = V1Decrypt(token, footer, &key)?;
+pub fn validate_local_token(token: &str, footer: Option<String>, key: &Vec<u8>) -> Result<Jsonvalue, Error> {
+  let token = V1Decrypt(token, footer, key)?;
   return validate_potential_json_blob(token);
 }
 
@@ -159,8 +159,8 @@ pub fn validate_local_token(token: String, footer: Option<String>, key: Vec<u8>)
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
 #[cfg(all(feature = "v2", not(feature = "v1")))]
-pub fn validate_local_token(token: String, footer: Option<String>, mut key: Vec<u8>) -> Result<Jsonvalue, Error> {
-  let token = V2Decrypt(token, footer, &mut key)?;
+pub fn validate_local_token(token: &str, footer: Option<String>, key: &Vec<u8>) -> Result<Jsonvalue, Error> {
+  let token = V2Decrypt(token, footer, key)?;
   return validate_potential_json_blob(token);
 }
 
@@ -177,16 +177,16 @@ pub fn validate_local_token(token: String, footer: Option<String>, mut key: Vec<
 ///   * subject
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
-pub fn validate_public_token(token: String, footer: Option<String>, key: PasetoPublicKey) -> Result<JsonValue, Error> {
+pub fn validate_public_token(token: &str, footer: Option<String>, key: &PasetoPublicKey) -> Result<JsonValue, Error> {
   if token.starts_with("v2.public.") {
     return match key {
       PasetoPublicKey::ED25519KeyPair(key_pair) => {
         let internal_msg = V2Verify(token, footer, key_pair.public_key().as_ref())?;
-        validate_potential_json_blob(internal_msg)
+        validate_potential_json_blob(&internal_msg)
       }
       PasetoPublicKey::ED25519PublicKey(pub_key_contents) => {
         let internal_msg = V2Verify(token, footer, &pub_key_contents)?;
-        validate_potential_json_blob(internal_msg)
+        validate_potential_json_blob(&internal_msg)
       }
       _ => Err(GenericError::NoKeyProvided {})?,
     };
@@ -194,7 +194,7 @@ pub fn validate_public_token(token: String, footer: Option<String>, key: PasetoP
     return match key {
       PasetoPublicKey::RSAPublicKey(key_content) => {
         let internal_msg = V1Verify(token, footer, &key_content)?;
-        validate_potential_json_blob(internal_msg)
+        validate_potential_json_blob(&internal_msg)
       }
       _ => Err(GenericError::NoKeyProvided {})?,
     };
@@ -217,7 +217,7 @@ pub fn validate_public_token(token: String, footer: Option<String>, key: PasetoP
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
 #[cfg(all(feature = "v1", not(feature = "v2")))]
-pub fn validate_public_token(token: String, footer: Option<String>, key: PasetoPublicKey) -> Result<Jsonvalue, Error> {
+pub fn validate_public_token(token: &str, footer: Option<String>, key: &PasetoPublicKey) -> Result<Jsonvalue, Error> {
   return match key {
     PasetoPublicKey::RSAPublicKey(key_content) => {
       let internal_msg = V1Verify(token, footer, &key_content)?;
@@ -278,7 +278,7 @@ mod unit_tests {
       .expect("Failed to construct paseto token w/ builder!");
 
     validate_local_token(
-      token,
+      &token,
       Some(String::from("footer")),
       Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
     )
@@ -305,7 +305,7 @@ mod unit_tests {
       .expect("Failed to construct paseto token w/ builder!");
 
     assert!(validate_local_token(
-      token,
+      &token,
       Some(String::from("footer")),
       Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes())
     )
@@ -337,9 +337,9 @@ mod unit_tests {
       .expect("Failed to construct paseto token w/ builder!");
 
     validate_public_token(
-      token,
+      &token,
       Some(String::from("footer")),
-      PasetoPublicKey::ED25519KeyPair(cloned_key),
+      &PasetoPublicKey::ED25519KeyPair(cloned_key),
     )
     .expect("Failed to validate token!");
   }
@@ -369,9 +369,9 @@ mod unit_tests {
       .expect("Failed to construct paseto token w/ builder!");
 
     validate_public_token(
-      token,
+      &token,
       Some(String::from("footer")),
-      PasetoPublicKey::ED25519PublicKey(Vec::from(cloned_key.public_key().as_ref())),
+      &PasetoPublicKey::ED25519PublicKey(Vec::from(cloned_key.public_key().as_ref())),
     )
     .expect("Failed to validate token!");
   }
@@ -401,9 +401,9 @@ mod unit_tests {
       .expect("Failed to construct paseto token w/ builder!");
 
     assert!(validate_public_token(
-      token,
+      &token,
       Some(String::from("footer")),
-      PasetoPublicKey::ED25519KeyPair(cloned_key)
+      &PasetoPublicKey::ED25519KeyPair(cloned_key)
     )
     .is_err());
   }

--- a/src/v1/local.rs
+++ b/src/v1/local.rs
@@ -16,7 +16,7 @@ use ring::rand::{SecureRandom, SystemRandom};
 /// Encrypt a "v1.local" paseto token.
 ///
 /// Returns a result of a string if encryption was successful.
-pub fn local_paseto(msg: String, footer: Option<String>, key: &[u8]) -> Result<String, Error> {
+pub fn local_paseto(msg: &str, footer: Option<String>, key: &[u8]) -> Result<String, Error> {
   let rng = SystemRandom::new();
   let mut buff: [u8; 32] = [0u8; 32];
   let res = rng.fill(&mut buff);
@@ -34,7 +34,7 @@ pub fn local_paseto(msg: String, footer: Option<String>, key: &[u8]) -> Result<S
 /// `random_nonce` - The random nonce.
 /// `key` - The key used for encryption.
 fn underlying_local_paseto(
-  msg: String,
+  msg: &str,
   footer: Option<String>,
   random_nonce: &[u8],
   key: &[u8],
@@ -102,7 +102,7 @@ fn underlying_local_paseto(
 /// `token` - The encrypted token.
 /// `footer` - The optional footer to validate against.
 /// `key` - The key used to encrypt the token.
-pub fn decrypt_paseto(token: String, footer: Option<String>, key: &[u8]) -> Result<String, Error> {
+pub fn decrypt_paseto(token: &str, footer: Option<String>, key: &[u8]) -> Result<String, Error> {
   let token_parts = token.split(".").map(|item| item.to_owned()).collect::<Vec<String>>();
   if token_parts.len() < 3 {
     return Err(GenericError::InvalidToken {})?;
@@ -187,11 +187,11 @@ mod unit_tests {
     rng.fill(&mut key_buff).expect("Failed to fill key_buff!");
 
     // Try to encrypt without footers.
-    let message_a = local_paseto(String::from("msg"), None, &key_buff).expect("Failed to encrypt V1 Paseto string");
+    let message_a = local_paseto("msg", None, &key_buff).expect("Failed to encrypt V1 Paseto string");
     // NOTE: This test is just ensuring we can encode a json object, remember these internal impls
     // don't check for expires being valid!
     let message_b = local_paseto(
-      String::from("{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"),
+      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
       None,
       &key_buff,
     )
@@ -200,8 +200,8 @@ mod unit_tests {
     assert!(message_a.starts_with("v1.local."));
     assert!(message_b.starts_with("v1.local."));
 
-    let decrypted_a = decrypt_paseto(message_a.clone(), None, &key_buff).expect("Failed to decrypt V1 Paseto String");
-    let decrypted_b = decrypt_paseto(message_b, None, &key_buff).expect("Failed to decrypt V1 Paseto JSON Blob");
+    let decrypted_a = decrypt_paseto(&message_a, None, &key_buff).expect("Failed to decrypt V1 Paseto String");
+    let decrypted_b = decrypt_paseto(&message_b, None, &key_buff).expect("Failed to decrypt V1 Paseto JSON Blob");
 
     assert_eq!(decrypted_a, String::from("msg"));
     assert_eq!(
@@ -209,14 +209,14 @@ mod unit_tests {
       String::from("{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}")
     );
 
-    let should_fail_decryption_a = decrypt_paseto(message_a, Some(String::from("data")), &key_buff);
+    let should_fail_decryption_a = decrypt_paseto(&message_a, Some(String::from("data")), &key_buff);
     assert!(should_fail_decryption_a.is_err());
 
     // Try with footers.
-    let message_c = local_paseto(String::from("msg"), Some(String::from("data")), &key_buff)
+    let message_c = local_paseto("msg", Some(String::from("data")), &key_buff)
       .expect("Failed to encrypt V1 Paseto String with footer!");
     let message_d = local_paseto(
-      String::from("{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"),
+      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
       Some(String::from("data")),
       &key_buff,
     )
@@ -225,9 +225,9 @@ mod unit_tests {
     assert!(message_c.starts_with("v1.local."));
     assert!(message_d.starts_with("v1.local."));
 
-    let decrypted_c = decrypt_paseto(message_c.clone(), Some(String::from("data")), &key_buff)
+    let decrypted_c = decrypt_paseto(&message_c, Some(String::from("data")), &key_buff)
       .expect("Failed to decrypt V1 Paseto String with footer!");
-    let decrypted_d = decrypt_paseto(message_d, Some(String::from("data")), &key_buff)
+    let decrypted_d = decrypt_paseto(&message_d, Some(String::from("data")), &key_buff)
       .expect("Failed to decrypt V1 Paseto Json Blob with footer!");
 
     assert_eq!(decrypted_c, "msg");
@@ -237,8 +237,8 @@ mod unit_tests {
     );
 
     // Try with no footer + invalid footer.
-    let should_fail_decryption_b = decrypt_paseto(message_c.clone(), None, &key_buff);
-    let should_fail_decryption_c = decrypt_paseto(message_c, Some(String::from("invalid")), &key_buff);
+    let should_fail_decryption_b = decrypt_paseto(&message_c, None, &key_buff);
+    let should_fail_decryption_c = decrypt_paseto(&message_c, Some(String::from("invalid")), &key_buff);
 
     assert!(should_fail_decryption_b.is_err());
     assert!(should_fail_decryption_c.is_err());

--- a/src/v1/local.rs
+++ b/src/v1/local.rs
@@ -16,7 +16,7 @@ use ring::rand::{SecureRandom, SystemRandom};
 /// Encrypt a "v1.local" paseto token.
 ///
 /// Returns a result of a string if encryption was successful.
-pub fn local_paseto(msg: &str, footer: Option<String>, key: &[u8]) -> Result<String, Error> {
+pub fn local_paseto(msg: &str, footer: Option<&str>, key: &[u8]) -> Result<String, Error> {
   let rng = SystemRandom::new();
   let mut buff: [u8; 32] = [0u8; 32];
   let res = rng.fill(&mut buff);
@@ -33,14 +33,9 @@ pub fn local_paseto(msg: &str, footer: Option<String>, key: &[u8]) -> Result<Str
 /// `footer` - The optional footer.
 /// `random_nonce` - The random nonce.
 /// `key` - The key used for encryption.
-fn underlying_local_paseto(
-  msg: &str,
-  footer: Option<String>,
-  random_nonce: &[u8],
-  key: &[u8],
-) -> Result<String, Error> {
+fn underlying_local_paseto(msg: &str, footer: Option<&str>, random_nonce: &[u8], key: &[u8]) -> Result<String, Error> {
   let header = String::from("v1.local.");
-  let footer_frd = footer.unwrap_or(String::default());
+  let footer_frd = footer.unwrap_or("");
   let true_nonce = calculate_hashed_nonce(msg.as_bytes(), random_nonce);
 
   let (as_salt, ctr_nonce) = true_nonce.split_at(16);
@@ -102,14 +97,14 @@ fn underlying_local_paseto(
 /// `token` - The encrypted token.
 /// `footer` - The optional footer to validate against.
 /// `key` - The key used to encrypt the token.
-pub fn decrypt_paseto(token: &str, footer: Option<String>, key: &[u8]) -> Result<String, Error> {
+pub fn decrypt_paseto(token: &str, footer: Option<&str>, key: &[u8]) -> Result<String, Error> {
   let token_parts = token.split(".").map(|item| item.to_owned()).collect::<Vec<String>>();
   if token_parts.len() < 3 {
     return Err(GenericError::InvalidToken {})?;
   }
 
   let is_footer_some = footer.is_some();
-  let footer_str = footer.unwrap_or(String::default());
+  let footer_str = footer.unwrap_or("");
 
   if is_footer_some {
     if token_parts.len() < 4 {
@@ -209,15 +204,15 @@ mod unit_tests {
       String::from("{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}")
     );
 
-    let should_fail_decryption_a = decrypt_paseto(&message_a, Some(String::from("data")), &key_buff);
+    let should_fail_decryption_a = decrypt_paseto(&message_a, Some("data"), &key_buff);
     assert!(should_fail_decryption_a.is_err());
 
     // Try with footers.
-    let message_c = local_paseto("msg", Some(String::from("data")), &key_buff)
-      .expect("Failed to encrypt V1 Paseto String with footer!");
+    let message_c =
+      local_paseto("msg", Some("data"), &key_buff).expect("Failed to encrypt V1 Paseto String with footer!");
     let message_d = local_paseto(
       "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
-      Some(String::from("data")),
+      Some("data"),
       &key_buff,
     )
     .expect("Failed to encrypt V1 Paseto Json blob with footer!");
@@ -225,10 +220,10 @@ mod unit_tests {
     assert!(message_c.starts_with("v1.local."));
     assert!(message_d.starts_with("v1.local."));
 
-    let decrypted_c = decrypt_paseto(&message_c, Some(String::from("data")), &key_buff)
-      .expect("Failed to decrypt V1 Paseto String with footer!");
-    let decrypted_d = decrypt_paseto(&message_d, Some(String::from("data")), &key_buff)
-      .expect("Failed to decrypt V1 Paseto Json Blob with footer!");
+    let decrypted_c =
+      decrypt_paseto(&message_c, Some("data"), &key_buff).expect("Failed to decrypt V1 Paseto String with footer!");
+    let decrypted_d =
+      decrypt_paseto(&message_d, Some("data"), &key_buff).expect("Failed to decrypt V1 Paseto Json Blob with footer!");
 
     assert_eq!(decrypted_c, "msg");
     assert_eq!(
@@ -238,7 +233,7 @@ mod unit_tests {
 
     // Try with no footer + invalid footer.
     let should_fail_decryption_b = decrypt_paseto(&message_c, None, &key_buff);
-    let should_fail_decryption_c = decrypt_paseto(&message_c, Some(String::from("invalid")), &key_buff);
+    let should_fail_decryption_c = decrypt_paseto(&message_c, Some("invalid"), &key_buff);
 
     assert!(should_fail_decryption_b.is_err());
     assert!(should_fail_decryption_c.is_err());

--- a/src/v2/local.rs
+++ b/src/v2/local.rs
@@ -13,7 +13,7 @@ use sodiumoxide::crypto::generichash::State as GenericHashState;
 /// Encrypt a "v2.local" paseto token.
 ///
 /// Returns a result of a string if encryption was successful.
-pub fn local_paseto(msg: &str, footer: Option<String>, key: &[u8]) -> Result<String, Error> {
+pub fn local_paseto(msg: &str, footer: Option<&str>, key: &[u8]) -> Result<String, Error> {
   let rng = SystemRandom::new();
   let mut buff: [u8; 24] = [0u8; 24];
   let res = rng.fill(&mut buff);
@@ -30,14 +30,9 @@ pub fn local_paseto(msg: &str, footer: Option<String>, key: &[u8]) -> Result<Str
 /// `footer` - The footer to add.
 /// `nonce_key` - The key to the nonce, should be securely generated.
 /// `key` - The key to encrypt the message with.
-fn underlying_local_paseto(
-  msg: &str,
-  footer: Option<String>,
-  nonce_key: &[u8; 24],
-  key: &[u8],
-) -> Result<String, Error> {
+fn underlying_local_paseto(msg: &str, footer: Option<&str>, nonce_key: &[u8; 24], key: &[u8]) -> Result<String, Error> {
   let header = String::from("v2.local.");
-  let footer_frd = footer.unwrap_or(String::default());
+  let footer_frd = footer.unwrap_or("");
   // Specify result type to give rust compiler hints on types.
   let res: Result<(Nonce, Vec<u8>), Error> = {
     if let Ok(mut state) = GenericHashState::new(24, Some(nonce_key)) {
@@ -97,14 +92,14 @@ fn underlying_local_paseto(
 /// `token`: The Token to decrypt.
 /// `footer`: The Optional footer to validate.
 /// `key`: The key to decrypt your Paseto.
-pub fn decrypt_paseto(token: &str, footer: Option<String>, key: &[u8]) -> Result<String, Error> {
+pub fn decrypt_paseto(token: &str, footer: Option<&str>, key: &[u8]) -> Result<String, Error> {
   let token_parts = token.split(".").map(|item| item.to_owned()).collect::<Vec<String>>();
   if token_parts.len() < 3 {
     return Err(GenericError::InvalidToken {})?;
   }
 
   let is_footer_some = footer.is_some();
-  let footer_str = footer.unwrap_or(String::default());
+  let footer_str = footer.unwrap_or("");
 
   if is_footer_some {
     if token_parts.len() < 4 {
@@ -186,7 +181,7 @@ mod unit_tests {
     let empty_key = [0; 32];
     let full_key = [255; 32];
 
-    let result = underlying_local_paseto("", Some(String::from("Cuon Alpinus")), &[0; 24], &empty_key);
+    let result = underlying_local_paseto("", Some("Cuon Alpinus"), &[0; 24], &empty_key);
     if result.is_err() {
       println!("Failed to encrypt Paseto!");
       println!("{:?}", result);
@@ -199,7 +194,7 @@ mod unit_tests {
       the_str
     );
 
-    let full_result = underlying_local_paseto("", Some(String::from("Cuon Alpinus")), &[0; 24], &full_key);
+    let full_result = underlying_local_paseto("", Some("Cuon Alpinus"), &[0; 24], &full_key);
     if full_result.is_err() {
       println!("Failed to encrypt Paseto!");
       println!("{:?}", full_result);
@@ -250,11 +245,7 @@ mod unit_tests {
   fn full_round_paseto() {
     let empty_key = [0; 32];
 
-    let result = local_paseto(
-      "Love is stronger than hate or fear",
-      Some(String::from("gwiz-bot")),
-      &empty_key,
-    );
+    let result = local_paseto("Love is stronger than hate or fear", Some("gwiz-bot"), &empty_key);
     if result.is_err() {
       println!("Failed to encrypt Paseto!");
       println!("{:?}", result);
@@ -264,7 +255,7 @@ mod unit_tests {
 
     println!("Paseto Full Round Token: [ {:?} ]", the_str);
 
-    let decrypted_result = decrypt_paseto(&the_str, Some(String::from("gwiz-bot")), &empty_key);
+    let decrypted_result = decrypt_paseto(&the_str, Some("gwiz-bot"), &empty_key);
     if decrypted_result.is_err() {
       println!("Failed to decrypt Paseto!");
       println!("{:?}", decrypted_result);


### PR DESCRIPTION
## Motivation ##

Switching from passing String to passing &str does a few things, namely:

1) denoting that ownership is not being passed into the procedure, making the relationship to the calling code more readable.
1) avoiding unnecessary clones.  The provided procedures only read the messages and keys in order to construct the token.
1) cleaning up many calling sites.  Taking &str allows callers to pass through a &str from another call (without having to call .to_string()) or use 'static string references (just take a look at how many of the tests were cleaned up of superfluous String::from()).

## Test Plan ##

Existing tests have been updated.  As this is mostly a parameter type change, existing tests should be sufficient.  Since Rust validates parameter lifetimes for use, the switch will be safe.
