### PR TITLE
Avoid taking ownership in the builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * High-level functions like `validate_local_token` and `validate_public_token` now take the `key` by reference.
 * The reference to `key` passed as argument to `v1::public::public_paseto` is not longer taken as mutable.
+* `tokens::PasetoBuilder` methods have been changed to only take references
 
 ## 1.0.7
 

--- a/examples/local-using-builders.rs
+++ b/examples/local-using-builders.rs
@@ -11,16 +11,16 @@ fn main() {
     let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
 
     let token = paseto::tokens::PasetoBuilder::new()
-      .set_encryption_key(Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
       .set_issued_at(None)
-      .set_expiration(dt)
-      .set_issuer(String::from("instructure"))
-      .set_audience(String::from("wizards"))
-      .set_jti(String::from("gandalf0"))
-      .set_not_before(Utc::now())
-      .set_subject(String::from("gandalf"))
-      .set_claim(String::from("go-to"), json!(String::from("mordor")))
-      .set_footer(String::from("key-id:gandalf0"))
+      .set_expiration(&dt)
+      .set_issuer("instructure")
+      .set_audience("wizards")
+      .set_jti("gandalf0")
+      .set_not_before(&Utc::now())
+      .set_subject("gandalf")
+      .set_claim("go-to", json!("mordor"))
+      .set_footer("key-id:gandalf0")
       .build()
       .expect("Failed to construct paseto token w/ builder!");
     println!("{:?}", token);

--- a/examples/public-using-builder.rs
+++ b/examples/public-using-builder.rs
@@ -15,19 +15,18 @@ fn main() {
     let sys_rand = SystemRandom::new();
     let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
     let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
-    let cloned_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
     let token = paseto::tokens::PasetoBuilder::new()
-      .set_ed25519_key(as_key)
+      .set_ed25519_key(&as_key)
       .set_issued_at(None)
-      .set_expiration(dt)
-      .set_issuer(String::from("instructure"))
-      .set_audience(String::from("wizards"))
-      .set_jti(String::from("gandalf0"))
-      .set_not_before(Utc::now())
-      .set_subject(String::from("gandalf"))
-      .set_claim(String::from("go-to"), json!(String::from("mordor")))
-      .set_footer(String::from("key-id:gandalf0"))
+      .set_expiration(&dt)
+      .set_issuer("instructure")
+      .set_audience("wizards")
+      .set_jti("gandalf0")
+      .set_not_before(&Utc::now())
+      .set_subject("gandalf")
+      .set_claim("go-to", json!("mordor"))
+      .set_footer("key-id:gandalf0")
       .build()
       .expect("Failed to construct paseto token w/ builder!");
     println!("{:?}", token);
@@ -35,9 +34,10 @@ fn main() {
     let verified_token = paseto::tokens::validate_public_token(
       &token,
       Some("key-id:gandalf0"),
-      &paseto::tokens::PasetoPublicKey::ED25519KeyPair(cloned_key),
+    &paseto::tokens::PasetoPublicKey::ED25519KeyPair(&as_key),
     )
     .expect("Failed to validate token!");
+
     println!("{:?}", verified_token);
   }
 }

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -19,13 +19,13 @@ pub use self::builder::*;
 
 /// Wraps the two paseto public key types so we can just have a `validate_public_token`
 /// method without splitting the two implementations.
-pub enum PasetoPublicKey {
+pub enum PasetoPublicKey<'a> {
   #[cfg(feature = "v1")]
-  RSAPublicKey(Vec<u8>),
+  RSAPublicKey(&'a [u8]),
   #[cfg(feature = "v2")]
-  ED25519KeyPair(Ed25519KeyPair),
+  ED25519KeyPair(&'a Ed25519KeyPair),
   #[cfg(feature = "v2")]
-  ED25519PublicKey(Vec<u8>),
+  ED25519PublicKey(&'a [u8]),
 }
 
 /// Validates a potential json data blob, returning a JsonValue.
@@ -199,16 +199,16 @@ mod unit_tests {
     let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
 
     let token = PasetoBuilder::new()
-      .set_encryption_key(Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
       .set_issued_at(None)
-      .set_expiration(dt)
-      .set_issuer(String::from("issuer"))
-      .set_audience(String::from("audience"))
-      .set_jti(String::from("jti"))
-      .set_not_before(Utc::now())
-      .set_subject(String::from("test"))
-      .set_claim(String::from("claim"), json!(String::from("data")))
-      .set_footer(String::from("footer"))
+      .set_expiration(&dt)
+      .set_issuer("issuer")
+      .set_audience("audience")
+      .set_jti("jti")
+      .set_not_before(&Utc::now())
+      .set_subject("test")
+      .set_claim("claim", json!("data"))
+      .set_footer("footer")
       .build()
       .expect("Failed to construct paseto token w/ builder!");
 
@@ -226,16 +226,16 @@ mod unit_tests {
     let dt = Utc.ymd(current_date_time.year() - 1, 7, 8).and_hms(9, 10, 11);
 
     let token = PasetoBuilder::new()
-      .set_encryption_key(Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
       .set_issued_at(None)
-      .set_expiration(dt)
-      .set_issuer(String::from("issuer"))
-      .set_audience(String::from("audience"))
-      .set_jti(String::from("jti"))
-      .set_not_before(Utc::now())
-      .set_subject(String::from("test"))
-      .set_claim(String::from("claim"), json!(String::from("data")))
-      .set_footer(String::from("footer"))
+      .set_expiration(&dt)
+      .set_issuer("issuer")
+      .set_audience("audience")
+      .set_jti("jti")
+      .set_not_before(&Utc::now())
+      .set_subject("test")
+      .set_claim("claim", json!("data"))
+      .set_footer("footer")
       .build()
       .expect("Failed to construct paseto token w/ builder!");
 
@@ -256,23 +256,22 @@ mod unit_tests {
     let sys_rand = SystemRandom::new();
     let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
     let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
-    let cloned_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
     let token = PasetoBuilder::new()
-      .set_ed25519_key(as_key)
+      .set_ed25519_key(&as_key)
       .set_issued_at(None)
-      .set_expiration(dt)
-      .set_issuer(String::from("issuer"))
-      .set_audience(String::from("audience"))
-      .set_jti(String::from("jti"))
-      .set_not_before(Utc::now())
-      .set_subject(String::from("test"))
-      .set_claim(String::from("claim"), json!(String::from("data")))
-      .set_footer(String::from("footer"))
+      .set_expiration(&dt)
+      .set_issuer("issuer")
+      .set_audience("audience")
+      .set_jti("jti")
+      .set_not_before(&Utc::now())
+      .set_subject("test")
+      .set_claim("claim", json!("data"))
+      .set_footer("footer")
       .build()
       .expect("Failed to construct paseto token w/ builder!");
 
-    validate_public_token(&token, Some("footer"), &PasetoPublicKey::ED25519KeyPair(cloned_key))
+    validate_public_token(&token, Some("footer"), &PasetoPublicKey::ED25519KeyPair(&as_key))
       .expect("Failed to validate token!");
   }
 
@@ -285,26 +284,25 @@ mod unit_tests {
     let sys_rand = SystemRandom::new();
     let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
     let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
-    let cloned_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
     let token = PasetoBuilder::new()
-      .set_ed25519_key(as_key)
+      .set_ed25519_key(&as_key)
       .set_issued_at(None)
-      .set_expiration(dt)
-      .set_issuer(String::from("issuer"))
-      .set_audience(String::from("audience"))
-      .set_jti(String::from("jti"))
-      .set_not_before(Utc::now())
-      .set_subject(String::from("test"))
-      .set_claim(String::from("claim"), json!(String::from("data")))
-      .set_footer(String::from("footer"))
+      .set_expiration(&dt)
+      .set_issuer("issuer")
+      .set_audience("audience")
+      .set_jti("jti")
+      .set_not_before(&Utc::now())
+      .set_subject("test")
+      .set_claim("claim", json!("data"))
+      .set_footer("footer")
       .build()
       .expect("Failed to construct paseto token w/ builder!");
 
     validate_public_token(
       &token,
       Some("footer"),
-      &PasetoPublicKey::ED25519PublicKey(Vec::from(cloned_key.public_key().as_ref())),
+      &PasetoPublicKey::ED25519PublicKey(as_key.public_key().as_ref()),
     )
     .expect("Failed to validate token!");
   }
@@ -318,22 +316,21 @@ mod unit_tests {
     let sys_rand = SystemRandom::new();
     let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
     let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
-    let cloned_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
     let token = PasetoBuilder::new()
-      .set_ed25519_key(as_key)
+      .set_ed25519_key(&as_key)
       .set_issued_at(None)
-      .set_expiration(dt)
-      .set_issuer(String::from("issuer"))
-      .set_audience(String::from("audience"))
-      .set_jti(String::from("jti"))
-      .set_not_before(Utc::now())
-      .set_subject(String::from("test"))
-      .set_claim(String::from("claim"), json!(String::from("data")))
-      .set_footer(String::from("footer"))
+      .set_expiration(&dt)
+      .set_issuer("issuer")
+      .set_audience("audience")
+      .set_jti("jti")
+      .set_not_before(&Utc::now())
+      .set_subject("test")
+      .set_claim("claim", json!("data"))
+      .set_footer("footer")
       .build()
       .expect("Failed to construct paseto token w/ builder!");
 
-    assert!(validate_public_token(&token, Some("footer"), &PasetoPublicKey::ED25519KeyPair(cloned_key)).is_err());
+    assert!(validate_public_token(&token, Some("footer"), &PasetoPublicKey::ED25519KeyPair(&as_key)).is_err());
   }
 }


### PR DESCRIPTION
This change make the builders only borrow things and never take ownership.

It also make all methods of the builder take `&mut self` allowing a lot more flexibility as described in
https://doc.rust-lang.org/1.0.0/style/ownership/builders.html

## Motivation ##

Trying to use the builders I remarked that I had to re-parse the key each time when using v2 public mode as `Ed25519KeyPair` can't be copied. Digging in the code I remarked that there was quite a few other parts of the builder that were forcing copies where they only needed a borrow so I fixed them too.

## Test Plan ##

I rand the tests after adapting them (Only a few changes needed) and they succeed.

## Next Steps ##

⚠ This PR changes the API so it's a major semver change I suspect⚠