### PR TITLE
PAE: Borrow arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 * Start running CI every night.
 * Upgrade openssl.
 * Upgrade Ring.
-* Remove Direct Dependncy on untrusted.
+* Remove direct dependency on untrusted.
 
 ## 1.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+* Change `pae::pae` to borrow a slice of slices (`&[&[u8]]`) instead of taking ownership of a `Vec<Vec<u8>>`.
 * High-level functions like `validate_local_token` and `validate_public_token` now take the `key` by reference.
 
 ## 1.0.7

--- a/src/pae.rs
+++ b/src/pae.rs
@@ -42,24 +42,23 @@ mod unit_tests {
 
   #[test]
   fn test_pae() {
-    let empty = &vec![] as &[u8];
     // Constants taken from paseto source.
-    assert_eq!("0000000000000000", hex::encode(&pae(vec![])));
+    assert_eq!("0000000000000000", hex::encode(&pae(&[])));
     assert_eq!(
       "01000000000000000000000000000000",
-      hex::encode(&pae(&vec![empty]))
+      hex::encode(&pae(&[&[]]))
     );
     assert_eq!(
       "020000000000000000000000000000000000000000000000",
-      hex::encode(&pae(&vec![empty, empty]))
+      hex::encode(&pae(&[&[], &[]]))
     );
     assert_eq!(
       "0100000000000000070000000000000050617261676f6e",
-      hex::encode(&pae(&vec!["Paragon".as_bytes()]))
+      hex::encode(&pae(&["Paragon".as_bytes()]))
     );
     assert_eq!(
       "0200000000000000070000000000000050617261676f6e0a00000000000000496e6974696174697665",
-      hex::encode(&pae(&vec![
+      hex::encode(&pae(&[
         "Paragon".as_bytes(),
         "Initiative".as_bytes(),
       ]))

--- a/src/pae.rs
+++ b/src/pae.rs
@@ -19,12 +19,12 @@ fn le64(mut to_encode: u64) -> Vec<u8> {
 /// Paseto Specification v2.
 ///
 /// * `pieces` - The Pieces to concatenate, and encode together.
-pub fn pae(pieces: Vec<Vec<u8>>) -> Vec<u8> {
+pub fn pae<'a>(pieces: &'a [&'a [u8]]) -> Vec<u8> {
   let the_vec = le64(pieces.len() as u64);
 
   pieces.into_iter().fold(the_vec, |mut acc, piece| {
     acc.extend(le64(piece.len() as u64));
-    acc.extend(piece);
+    acc.extend(piece.into_iter());
     acc
   })
 }
@@ -42,25 +42,26 @@ mod unit_tests {
 
   #[test]
   fn test_pae() {
+    let empty = &vec![] as &[u8];
     // Constants taken from paseto source.
     assert_eq!("0000000000000000", hex::encode(&pae(vec![])));
     assert_eq!(
       "01000000000000000000000000000000",
-      hex::encode(&pae(vec![vec![]]))
+      hex::encode(&pae(&vec![empty]))
     );
     assert_eq!(
       "020000000000000000000000000000000000000000000000",
-      hex::encode(&pae(vec![vec![], vec![]]))
+      hex::encode(&pae(&vec![empty, empty]))
     );
     assert_eq!(
       "0100000000000000070000000000000050617261676f6e",
-      hex::encode(&pae(vec![Vec::from("Paragon".as_bytes())]))
+      hex::encode(&pae(&vec!["Paragon".as_bytes()]))
     );
     assert_eq!(
       "0200000000000000070000000000000050617261676f6e0a00000000000000496e6974696174697665",
-      hex::encode(&pae(vec![
-        Vec::from("Paragon".as_bytes()),
-        Vec::from("Initiative".as_bytes()),
+      hex::encode(&pae(&vec![
+        "Paragon".as_bytes(),
+        "Initiative".as_bytes(),
       ]))
     );
   }

--- a/src/v1/local.rs
+++ b/src/v1/local.rs
@@ -13,6 +13,8 @@ use ring::hkdf::{Salt, HKDF_SHA384};
 use ring::hmac::{sign, Key, HMAC_SHA384};
 use ring::rand::{SecureRandom, SystemRandom};
 
+const HEADER: &str = "v1.local.";
+
 /// Encrypt a "v1.local" paseto token.
 ///
 /// Returns a result of a string if encryption was successful.
@@ -34,7 +36,6 @@ pub fn local_paseto(msg: &str, footer: Option<&str>, key: &[u8]) -> Result<Strin
 /// `random_nonce` - The random nonce.
 /// `key` - The key used for encryption.
 fn underlying_local_paseto(msg: &str, footer: Option<&str>, random_nonce: &[u8], key: &[u8]) -> Result<String, Error> {
-  let header = "v1.local.";
   let footer_frd = footer.unwrap_or("");
   let true_nonce = calculate_hashed_nonce(msg.as_bytes(), random_nonce);
 
@@ -62,11 +63,11 @@ fn underlying_local_paseto(msg: &str, footer: Option<&str>, random_nonce: &[u8],
   let cipher = symm::Cipher::aes_256_ctr();
   let crypted = symm::encrypt(cipher, &ek, Some(&ctr_nonce), msg.as_bytes())?;
 
-  let pre_auth = pae(vec![
-    Vec::from(header.as_bytes()),
-    true_nonce.clone(),
-    crypted.clone(),
-    Vec::from(footer_frd.as_bytes()),
+  let pre_auth = pae(&vec![
+    HEADER.as_bytes(),
+    &true_nonce,
+    &crypted,
+    footer_frd.as_bytes(),
   ]);
 
   let mac_key = Key::new(HMAC_SHA384, &ak);
@@ -79,11 +80,11 @@ fn underlying_local_paseto(msg: &str, footer: Option<&str>, random_nonce: &[u8],
   concated_together.extend_from_slice(&raw_bytes_from_hmac);
 
   let token = if footer_frd.is_empty() {
-    format!("{}{}", header, encode_config(&concated_together, URL_SAFE_NO_PAD))
+    format!("{}{}", HEADER, encode_config(&concated_together, URL_SAFE_NO_PAD))
   } else {
     format!(
       "{}{}.{}",
-      header,
+      HEADER,
       encode_config(&concated_together, URL_SAFE_NO_PAD),
       encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
     )
@@ -149,11 +150,11 @@ pub fn decrypt_paseto(token: &str, footer: Option<&str>, key: &[u8]) -> Result<S
     return Err(GenericError::BadHkdf {})?;
   }
 
-  let pre_auth = pae(vec![
-    Vec::from("v1.local.".as_bytes()),
-    nonce.clone(),
-    Vec::from(ciphertext),
-    Vec::from(footer_str.as_bytes()),
+  let pre_auth = pae(&vec![
+    HEADER.as_bytes(),
+    &nonce,
+    ciphertext,
+    footer_str.as_bytes(),
   ]);
 
   let mac_key = Key::new(HMAC_SHA384, &ak);

--- a/src/v1/local.rs
+++ b/src/v1/local.rs
@@ -63,7 +63,7 @@ fn underlying_local_paseto(msg: &str, footer: Option<&str>, random_nonce: &[u8],
   let cipher = symm::Cipher::aes_256_ctr();
   let crypted = symm::encrypt(cipher, &ek, Some(&ctr_nonce), msg.as_bytes())?;
 
-  let pre_auth = pae(&vec![
+  let pre_auth = pae(&[
     HEADER.as_bytes(),
     &true_nonce,
     &crypted,
@@ -150,7 +150,7 @@ pub fn decrypt_paseto(token: &str, footer: Option<&str>, key: &[u8]) -> Result<S
     return Err(GenericError::BadHkdf {})?;
   }
 
-  let pre_auth = pae(&vec![
+  let pre_auth = pae(&[
     HEADER.as_bytes(),
     &nonce,
     ciphertext,

--- a/src/v1/public.rs
+++ b/src/v1/public.rs
@@ -21,7 +21,7 @@ pub fn public_paseto(msg: &str, footer: Option<&str>, key_pair: &mut RsaKeyPair)
   }
   let footer_frd = footer.unwrap_or("");
 
-  let pre_auth = pae(&vec![
+  let pre_auth = pae(&[
     HEADER.as_bytes(),
     msg.as_bytes(),
     footer_frd.as_bytes(),
@@ -83,7 +83,7 @@ pub fn verify_paseto(token: &str, footer: Option<&str>, public_key: &[u8]) -> Re
   let decoded_len = decoded.len();
   let (message, sig) = decoded.split_at(decoded_len - 256);
 
-  let pre_auth = pae(&vec![
+  let pre_auth = pae(&[
     HEADER.as_bytes(),
     message,
     footer_as_str.as_bytes(),

--- a/src/v1/public.rs
+++ b/src/v1/public.rs
@@ -10,6 +10,8 @@ use ring::constant_time::verify_slices_are_equal as ConstantTimeEquals;
 use ring::rand::SystemRandom;
 use ring::signature::{RsaKeyPair, UnparsedPublicKey, RSA_PSS_2048_8192_SHA384, RSA_PSS_SHA384};
 
+const HEADER: &str = "v1.public.";
+
 /// Sign a "v1.public" paseto token.
 ///
 /// Returns a result of a string if signing was successful.
@@ -19,11 +21,10 @@ pub fn public_paseto(msg: &str, footer: Option<&str>, key_pair: &mut RsaKeyPair)
   }
   let footer_frd = footer.unwrap_or("");
 
-  let header = "v1.public.";
-  let pre_auth = pae(vec![
-    Vec::from(header.as_bytes()),
-    Vec::from(msg.as_bytes()),
-    Vec::from(footer_frd.as_bytes()),
+  let pre_auth = pae(&vec![
+    HEADER.as_bytes(),
+    msg.as_bytes(),
+    footer_frd.as_bytes(),
   ]);
   let random = SystemRandom::new();
 
@@ -38,11 +39,11 @@ pub fn public_paseto(msg: &str, footer: Option<&str>, key_pair: &mut RsaKeyPair)
   combined_vec.extend_from_slice(&signed_msg);
 
   let token = if footer_frd.is_empty() {
-    format!("{}{}", header, encode_config(&combined_vec, URL_SAFE_NO_PAD))
+    format!("{}{}", HEADER, encode_config(&combined_vec, URL_SAFE_NO_PAD))
   } else {
     format!(
       "{}{}.{}",
-      header,
+      HEADER,
       encode_config(&combined_vec, URL_SAFE_NO_PAD),
       encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
     )
@@ -82,10 +83,10 @@ pub fn verify_paseto(token: &str, footer: Option<&str>, public_key: &[u8]) -> Re
   let decoded_len = decoded.len();
   let (message, sig) = decoded.split_at(decoded_len - 256);
 
-  let pre_auth = pae(vec![
-    Vec::from("v1.public.".as_bytes()),
-    Vec::from(message),
-    Vec::from(footer_as_str.as_bytes()),
+  let pre_auth = pae(&vec![
+    HEADER.as_bytes(),
+    message,
+    footer_as_str.as_bytes(),
   ]);
 
   let pk_unparsed = UnparsedPublicKey::new(&RSA_PSS_2048_8192_SHA384, public_key);

--- a/src/v2/local.rs
+++ b/src/v2/local.rs
@@ -46,7 +46,7 @@ fn underlying_local_paseto(msg: &str, footer: Option<&str>, nonce_key: &[u8; 24]
           }
           let key_obj = key_obj.unwrap();
 
-          let pre_auth = pae(&vec![
+          let pre_auth = pae(&[
             HEADER.as_bytes(),
             &nonce_bytes,
             footer_frd.as_bytes(),
@@ -116,7 +116,7 @@ pub fn decrypt_paseto(token: &str, footer: Option<&str>, key: &[u8]) -> Result<S
   let mut decoded = decode_config(token_parts[2].as_bytes(), URL_SAFE_NO_PAD)?;
   let (nonce, ciphertext) = decoded.split_at_mut(24);
 
-  let pre_auth = pae(&vec![
+  let pre_auth = pae(&[
     HEADER.as_bytes(),
     nonce,
     footer_str.as_bytes(),

--- a/src/v2/local.rs
+++ b/src/v2/local.rs
@@ -10,6 +10,8 @@ use ring::rand::{SecureRandom, SystemRandom};
 use sodiumoxide::crypto::aead::xchacha20poly1305_ietf::{open as Decrypt, seal as Encrypt, Key, Nonce};
 use sodiumoxide::crypto::generichash::State as GenericHashState;
 
+const HEADER: &str = "v2.local.";
+
 /// Encrypt a "v2.local" paseto token.
 ///
 /// Returns a result of a string if encryption was successful.
@@ -31,20 +33,43 @@ pub fn local_paseto(msg: &str, footer: Option<&str>, key: &[u8]) -> Result<Strin
 /// `nonce_key` - The key to the nonce, should be securely generated.
 /// `key` - The key to encrypt the message with.
 fn underlying_local_paseto(msg: &str, footer: Option<&str>, nonce_key: &[u8; 24], key: &[u8]) -> Result<String, Error> {
-  let header = "v2.local.";
   let footer_frd = footer.unwrap_or("");
-  // Specify result type to give rust compiler hints on types.
-  let res: Result<(Nonce, Vec<u8>), Error> = {
-    if let Ok(mut state) = GenericHashState::new(24, Some(nonce_key)) {
-      if let Ok(_) = state.update(msg.as_bytes()) {
-        if let Ok(finalized) = state.finalize() {
-          let ref_finalized = finalized.as_ref();
-          if let Some(nonce) = Nonce::from_slice(ref_finalized) {
-            let to_return: (Nonce, Vec<u8>) = (nonce, Vec::from(ref_finalized));
-            Ok(to_return)
-          } else {
-            Err(SodiumErrors::FunctionError {})?
+
+  if let Ok(mut state) = GenericHashState::new(24, Some(nonce_key)) {
+    if let Ok(_) = state.update(msg.as_bytes()) {
+      if let Ok(finalized) = state.finalize() {
+        let nonce_bytes = finalized.as_ref();
+        if let Some(nonce) = Nonce::from_slice(nonce_bytes) {
+          let key_obj = Key::from_slice(key);
+          if key_obj.is_none() {
+            return Err(SodiumErrors::InvalidKey {})?;
           }
+          let key_obj = key_obj.unwrap();
+
+          let pre_auth = pae(&vec![
+            HEADER.as_bytes(),
+            &nonce_bytes,
+            footer_frd.as_bytes(),
+          ]);
+
+          let crypted = Encrypt(msg.as_bytes(), Some(pre_auth.as_ref()), &nonce, &key_obj);
+
+          let mut n_and_c = Vec::new();
+          n_and_c.extend_from_slice(&nonce_bytes);
+          n_and_c.extend_from_slice(&crypted);
+
+          let token = if !footer_frd.is_empty() {
+            format!(
+              "{}{}.{}",
+              HEADER,
+              encode_config(&n_and_c, URL_SAFE_NO_PAD),
+              encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
+            )
+          } else {
+            format!("{}{}", HEADER, encode_config(&n_and_c, URL_SAFE_NO_PAD))
+          };
+
+          Ok(token)
         } else {
           Err(SodiumErrors::FunctionError {})?
         }
@@ -54,37 +79,9 @@ fn underlying_local_paseto(msg: &str, footer: Option<&str>, nonce_key: &[u8; 24]
     } else {
       Err(SodiumErrors::FunctionError {})?
     }
-  };
-  let (nonce, nonce_vec) = res?;
-  let key_obj = Key::from_slice(key);
-  if key_obj.is_none() {
-    return Err(SodiumErrors::InvalidKey {})?;
-  }
-  let key_obj = key_obj.unwrap();
-
-  let header_as_vec = Vec::from(header.as_bytes());
-  let footer_as_vec = Vec::from(footer_frd.as_bytes());
-
-  let pre_auth = pae(vec![header_as_vec, nonce_vec.clone(), footer_as_vec]);
-
-  let crypted = Encrypt(msg.as_bytes(), Some(pre_auth.as_ref()), &nonce, &key_obj);
-
-  let mut n_and_c = Vec::new();
-  n_and_c.extend_from_slice(&nonce_vec);
-  n_and_c.extend_from_slice(&crypted);
-
-  let token = if !footer_frd.is_empty() {
-    format!(
-      "{}{}.{}",
-      header,
-      encode_config(&n_and_c, URL_SAFE_NO_PAD),
-      encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
-    )
   } else {
-    format!("{}{}", header, encode_config(&n_and_c, URL_SAFE_NO_PAD))
-  };
-
-  Ok(token)
+    Err(SodiumErrors::FunctionError {})?
+  }
 }
 
 /// Decrypt a Paseto TOKEN, validating against an optional footer.
@@ -119,10 +116,11 @@ pub fn decrypt_paseto(token: &str, footer: Option<&str>, key: &[u8]) -> Result<S
   let mut decoded = decode_config(token_parts[2].as_bytes(), URL_SAFE_NO_PAD)?;
   let (nonce, ciphertext) = decoded.split_at_mut(24);
 
-  let static_header = Vec::from("v2.local.".as_bytes());
-  let vecd_nonce = nonce.to_vec();
-  let vecd_footer = Vec::from(footer_str.as_bytes());
-  let pre_auth = pae(vec![static_header, vecd_nonce, vecd_footer]);
+  let pre_auth = pae(&vec![
+    HEADER.as_bytes(),
+    nonce,
+    footer_str.as_bytes(),
+  ]);
 
   let nonce_obj = Nonce::from_slice(nonce);
   let key_obj = Key::from_slice(key);

--- a/src/v2/public.rs
+++ b/src/v2/public.rs
@@ -9,17 +9,18 @@ use failure::Error;
 use ring::constant_time::verify_slices_are_equal as ConstantTimeEquals;
 use ring::signature::{Ed25519KeyPair, UnparsedPublicKey, ED25519};
 
+const HEADER: &str = "v2.public.";
+
 /// Sign a "v2.public" paseto token.
 ///
 /// Returns a result of a string if signing was successful.
 pub fn public_paseto(msg: &str, footer: Option<&str>, key_pair: &Ed25519KeyPair) -> Result<String, Error> {
-  let header = "v2.public.";
   let footer_frd = footer.unwrap_or("");
 
-  let pre_auth = pae(vec![
-    Vec::from(header.as_bytes()),
-    Vec::from(msg.as_bytes()),
-    Vec::from(footer_frd.as_bytes()),
+  let pre_auth = pae(&vec![
+    HEADER.as_bytes(),
+    msg.as_bytes(),
+    footer_frd.as_bytes(),
   ]);
 
   let sig = key_pair.sign(&pre_auth);
@@ -27,11 +28,11 @@ pub fn public_paseto(msg: &str, footer: Option<&str>, key_pair: &Ed25519KeyPair)
   m_and_sig.extend_from_slice(sig.as_ref());
 
   let token = if footer_frd.is_empty() {
-    format!("{}{}", header, encode_config(&m_and_sig, URL_SAFE_NO_PAD))
+    format!("{}{}", HEADER, encode_config(&m_and_sig, URL_SAFE_NO_PAD))
   } else {
     format!(
       "{}{}.{}",
-      header,
+      HEADER,
       encode_config(&m_and_sig, URL_SAFE_NO_PAD),
       encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
     )
@@ -71,10 +72,10 @@ pub fn verify_paseto(token: &str, footer: Option<&str>, public_key: &[u8]) -> Re
   let decoded_len = decoded.len();
   let (msg, sig) = decoded.split_at(decoded_len - 64);
 
-  let pre_auth = pae(vec![
-    Vec::from("v2.public.".as_bytes()),
-    Vec::from(msg),
-    Vec::from(footer_as_str.as_bytes()),
+  let pre_auth = pae(&vec![
+    HEADER.as_bytes(),
+    msg,
+    footer_as_str.as_bytes(),
   ]);
 
   let pk_unparsed = UnparsedPublicKey::new(&ED25519, public_key);

--- a/src/v2/public.rs
+++ b/src/v2/public.rs
@@ -17,7 +17,7 @@ const HEADER: &str = "v2.public.";
 pub fn public_paseto(msg: &str, footer: Option<&str>, key_pair: &Ed25519KeyPair) -> Result<String, Error> {
   let footer_frd = footer.unwrap_or("");
 
-  let pre_auth = pae(&vec![
+  let pre_auth = pae(&[
     HEADER.as_bytes(),
     msg.as_bytes(),
     footer_frd.as_bytes(),
@@ -72,7 +72,7 @@ pub fn verify_paseto(token: &str, footer: Option<&str>, public_key: &[u8]) -> Re
   let decoded_len = decoded.len();
   let (msg, sig) = decoded.split_at(decoded_len - 64);
 
-  let pre_auth = pae(&vec![
+  let pre_auth = pae(&[
     HEADER.as_bytes(),
     msg,
     footer_as_str.as_bytes(),


### PR DESCRIPTION
## Motivation ##

This change avoid having to copy things to pass them to the `pae::pae` method.

## Test Plan ##

Ran `cargo test`

## Next Steps ##

⚠ Like #18 this one is a breaking change ⚠