### PR TITLE
Simplify features build

### DIFF
--- a/examples/direct-protocol.rs
+++ b/examples/direct-protocol.rs
@@ -1,33 +1,39 @@
 fn main() {
   let key = "YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes();
-  let mut key_mut = Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes());
+  let mut key_mut = Vec::from(key);
   let message = "This is a signed non-JSON message.";
   let footer = "key-id:gandalf0";
 
-  // Version 1
-  let v1_token = paseto::v1::local::local_paseto(&message, None, key).expect("Failed to encrypt V1 Token sans footer.");
-  println!("{:?}", v1_token);
-  let decrypted_v1_token =
-    paseto::v1::local::decrypt_paseto(&v1_token, None, key).expect("Failed to decrypt V1 Token sans footer.");
-  println!("{:?}", decrypted_v1_token);
-  let v1_footer_token =
-    paseto::v1::local::local_paseto(&message, Some(&footer), key).expect("Failed to encrypt V1 Token.");
-  println!("{:?}", v1_footer_token);
-  let decrypted_v1_footer_token =
-    paseto::v1::local::decrypt_paseto(&v1_footer_token, Some(&footer), key).expect("Failed to decrypt V1 Token.");
-  println!("{:?}", decrypted_v1_footer_token);
+  #[cfg(feature = "v1")]
+  {
+    // Version 1
+    let v1_token = paseto::v1::local::local_paseto(&message, None, key).expect("Failed to encrypt V1 Token sans footer.");
+    println!("{:?}", v1_token);
+    let decrypted_v1_token =
+      paseto::v1::local::decrypt_paseto(&v1_token, None, key).expect("Failed to decrypt V1 Token sans footer.");
+    println!("{:?}", decrypted_v1_token);
+    let v1_footer_token =
+      paseto::v1::local::local_paseto(&message, Some(&footer), key).expect("Failed to encrypt V1 Token.");
+    println!("{:?}", v1_footer_token);
+    let decrypted_v1_footer_token =
+      paseto::v1::local::decrypt_paseto(&v1_footer_token, Some(&footer), key).expect("Failed to decrypt V1 Token.");
+    println!("{:?}", decrypted_v1_footer_token);
+  }
 
-  // Version 2
-  let v2_token =
-    paseto::v2::local::local_paseto(&message, None, &mut key_mut).expect("Failed to encrypt V2 Token sans footer.");
-  println!("{:?}", v2_token);
-  let decrypted_v2_token =
-    paseto::v2::local::decrypt_paseto(&v2_token, None, &mut key_mut).expect("Failed to decrypt V2 Token sans footer.");
-  println!("{:?}", decrypted_v2_token);
-  let v2_footer_token =
-    paseto::v2::local::local_paseto(&message, Some(&footer), &mut key_mut).expect("Failed to encrypt V2 Token.");
-  println!("{:?}", v2_footer_token);
-  let decrypted_v2_footer = paseto::v2::local::decrypt_paseto(&v2_footer_token, Some(&footer), &mut key_mut)
-    .expect("Failed to decrypt V2 Token.");
-  println!("{:?}", decrypted_v2_footer);
+  #[cfg(feature = "v2")]
+  {
+    // Version 2
+    let v2_token =
+      paseto::v2::local::local_paseto(&message, None, &mut key_mut).expect("Failed to encrypt V2 Token sans footer.");
+    println!("{:?}", v2_token);
+    let decrypted_v2_token =
+      paseto::v2::local::decrypt_paseto(&v2_token, None, &mut key_mut).expect("Failed to decrypt V2 Token sans footer.");
+    println!("{:?}", decrypted_v2_token);
+    let v2_footer_token =
+      paseto::v2::local::local_paseto(&message, Some(&footer), &mut key_mut).expect("Failed to encrypt V2 Token.");
+    println!("{:?}", v2_footer_token);
+    let decrypted_v2_footer = paseto::v2::local::decrypt_paseto(&v2_footer_token, Some(&footer), &mut key_mut)
+      .expect("Failed to decrypt V2 Token.");
+    println!("{:?}", decrypted_v2_footer);
+  }
 }

--- a/examples/local-using-builders.rs
+++ b/examples/local-using-builders.rs
@@ -1,30 +1,36 @@
-use chrono::prelude::*;
-use serde_json::json;
+#[cfg(feature = "easy_tokens")]
+use {
+  chrono::prelude::*,
+  serde_json::json,
+};
 
 fn main() {
-  let current_date_time = Utc::now();
-  let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+  #[cfg(feature = "easy_tokens")]
+  {
+    let current_date_time = Utc::now();
+    let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
 
-  let token = paseto::tokens::PasetoBuilder::new()
-    .set_encryption_key(Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-    .set_issued_at(None)
-    .set_expiration(dt)
-    .set_issuer(String::from("instructure"))
-    .set_audience(String::from("wizards"))
-    .set_jti(String::from("gandalf0"))
-    .set_not_before(Utc::now())
-    .set_subject(String::from("gandalf"))
-    .set_claim(String::from("go-to"), json!(String::from("mordor")))
-    .set_footer(String::from("key-id:gandalf0"))
-    .build()
-    .expect("Failed to construct paseto token w/ builder!");
-  println!("{:?}", token);
+    let token = paseto::tokens::PasetoBuilder::new()
+      .set_encryption_key(Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+      .set_issued_at(None)
+      .set_expiration(dt)
+      .set_issuer(String::from("instructure"))
+      .set_audience(String::from("wizards"))
+      .set_jti(String::from("gandalf0"))
+      .set_not_before(Utc::now())
+      .set_subject(String::from("gandalf"))
+      .set_claim(String::from("go-to"), json!(String::from("mordor")))
+      .set_footer(String::from("key-id:gandalf0"))
+      .build()
+      .expect("Failed to construct paseto token w/ builder!");
+    println!("{:?}", token);
 
-  let verified_token = paseto::tokens::validate_local_token(
-    &token,
-    Some("key-id:gandalf0"),
-    &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
-  )
-  .expect("Failed to validate token!");
-  println!("{:?}", verified_token);
+    let verified_token = paseto::tokens::validate_local_token(
+      &token,
+      Some("key-id:gandalf0"),
+      &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+    )
+    .expect("Failed to validate token!");
+    println!("{:?}", verified_token);
+  }
 }

--- a/examples/public-using-builder.rs
+++ b/examples/public-using-builder.rs
@@ -1,10 +1,13 @@
-use chrono::prelude::*;
-use ring::rand::SystemRandom;
-use ring::signature::Ed25519KeyPair;
-use serde_json::json;
+#[cfg(all(feature = "v2", feature = "easy_tokens"))]
+use {
+  chrono::prelude::*,
+  ring::rand::SystemRandom,
+  ring::signature::Ed25519KeyPair,
+  serde_json::json,
+};
 
 fn main() {
-  #[cfg(feature = "v2")]
+  #[cfg(all(feature = "v2", feature = "easy_tokens"))]
   {
     let current_date_time = Utc::now();
     let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);

--- a/examples/public-using-builder.rs
+++ b/examples/public-using-builder.rs
@@ -4,34 +4,37 @@ use ring::signature::Ed25519KeyPair;
 use serde_json::json;
 
 fn main() {
-  let current_date_time = Utc::now();
-  let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+  #[cfg(feature = "v2")]
+  {
+    let current_date_time = Utc::now();
+    let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
 
-  let sys_rand = SystemRandom::new();
-  let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
-  let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
-  let cloned_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+    let sys_rand = SystemRandom::new();
+    let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+    let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+    let cloned_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
-  let token = paseto::tokens::PasetoBuilder::new()
-    .set_ed25519_key(as_key)
-    .set_issued_at(None)
-    .set_expiration(dt)
-    .set_issuer(String::from("instructure"))
-    .set_audience(String::from("wizards"))
-    .set_jti(String::from("gandalf0"))
-    .set_not_before(Utc::now())
-    .set_subject(String::from("gandalf"))
-    .set_claim(String::from("go-to"), json!(String::from("mordor")))
-    .set_footer(String::from("key-id:gandalf0"))
-    .build()
-    .expect("Failed to construct paseto token w/ builder!");
-  println!("{:?}", token);
+    let token = paseto::tokens::PasetoBuilder::new()
+      .set_ed25519_key(as_key)
+      .set_issued_at(None)
+      .set_expiration(dt)
+      .set_issuer(String::from("instructure"))
+      .set_audience(String::from("wizards"))
+      .set_jti(String::from("gandalf0"))
+      .set_not_before(Utc::now())
+      .set_subject(String::from("gandalf"))
+      .set_claim(String::from("go-to"), json!(String::from("mordor")))
+      .set_footer(String::from("key-id:gandalf0"))
+      .build()
+      .expect("Failed to construct paseto token w/ builder!");
+    println!("{:?}", token);
 
-  let verified_token = paseto::tokens::validate_public_token(
-    &token,
-    Some("key-id:gandalf0"),
-    &paseto::tokens::PasetoPublicKey::ED25519KeyPair(cloned_key),
-  )
-  .expect("Failed to validate token!");
-  println!("{:?}", verified_token);
+    let verified_token = paseto::tokens::validate_public_token(
+      &token,
+      Some("key-id:gandalf0"),
+      &paseto::tokens::PasetoPublicKey::ED25519KeyPair(cloned_key),
+    )
+    .expect("Failed to validate token!");
+    println!("{:?}", verified_token);
+  }
 }

--- a/src/tokens/builder.rs
+++ b/src/tokens/builder.rs
@@ -35,14 +35,15 @@ pub struct PasetoBuilder {
   extra_claims: HashMap<String, Value>,
 }
 
-#[cfg(all(feature = "v1", feature = "v2"))]
 impl PasetoBuilder {
   /// Creates a new Paseto builder.
   pub fn new() -> PasetoBuilder {
     PasetoBuilder {
       footer: None,
       encryption_key: None,
+      #[cfg(feature = "v1")]
       rsa_key: None,
+      #[cfg(feature = "v2")]
       ed_key: None,
       extra_claims: HashMap::new(),
     }
@@ -52,77 +53,33 @@ impl PasetoBuilder {
   pub fn build(self) -> Result<String, Error> {
     let strd_msg = to_string(&self.extra_claims)?;
 
-    if let Some(mut enc_key) = self.encryption_key {
-      return V2Local(&strd_msg, self.footer.as_deref(), &mut enc_key);
-    } else if let Some(ed_key_pair) = self.ed_key {
-      return V2Public(&strd_msg, self.footer.as_deref(), &ed_key_pair);
-    } else if let Some(the_rsa_key) = self.rsa_key {
-      let key_pair = RsaKeyPair::from_der(&the_rsa_key);
-      if key_pair.is_err() {
-        return Err(RsaKeyErrors::InvalidKey {})?;
+    #[cfg(feature = "v2")]
+    {
+      if let Some(mut enc_key) = self.encryption_key {
+        return V2Local(&strd_msg, self.footer.as_deref(), &mut enc_key);
       }
-      let mut key_pair = key_pair.unwrap();
-      return V1Public(&strd_msg, self.footer.as_deref(), &mut key_pair);
-    } else {
-      return Err(GenericError::NoKeyProvided {})?;
     }
-  }
-}
 
-#[cfg(all(not(feature = "v2"), feature = "v1"))]
-impl PasetoBuilder {
-  /// Creates a new Paseto builder.
-  pub fn new() -> PasetoBuilder {
-    PasetoBuilder {
-      footer: None,
-      encryption_key: None,
-      rsa_key: None,
-      extra_claims: HashMap::new(),
-    }
-  }
-
-  /// Builds a token.
-  pub fn build(self) -> Result<String, Error> {
-    let strd_msg = to_string(&self.extra_claims)?;
-
-    if let Some(mut enc_key) = self.encryption_key {
-      return V1Local(&strd_msg, self.footer.as_deref(), &mut enc_key);
-    } else if let Some(the_rsa_key) = self.rsa_key {
-      let key_pair = RsaKeyPair::from_der(&the_rsa_key);
-      if key_pair.is_err() {
-        return Err(RsaKeyErrors::InvalidKey {})?;
+    #[cfg(feature = "v2")]
+    {
+      if let Some(ed_key_pair) = self.ed_key {
+        return V2Public(&strd_msg, self.footer.as_deref(), &ed_key_pair);
       }
-      let mut key_pair = key_pair.unwrap();
-      return V1Public(&strd_msg, self.footer.as_deref(), &mut key_pair);
-    } else {
-      return Err(GenericError::NoKeyProvided {})?;
     }
-  }
-}
 
-#[cfg(all(not(feature = "v1"), feature = "v2"))]
-impl PasetoBuilder {
-  /// Creates a new Paseto builder.
-  pub fn new() -> PasetoBuilder {
-    PasetoBuilder {
-      footer: None,
-      encryption_key: None,
-      ed_key: None,
-      extra_claims: HashMap::new(),
+    #[cfg(feature = "v1")]
+    {
+      if let Some(the_rsa_key) = self.rsa_key {
+        let key_pair = RsaKeyPair::from_der(&the_rsa_key);
+        if key_pair.is_err() {
+          return Err(RsaKeyErrors::InvalidKey {})?;
+        }
+        let mut key_pair = key_pair.unwrap();
+        return V1Public(&strd_msg, self.footer.as_deref(), &mut key_pair);
+      }
     }
-  }
 
-  /// Builds a token.
-  pub fn build(self) -> Result<String, Error> {
-    let strd_msg = to_string(&self.extra_claims)?;
-
-    if let Some(mut enc_key) = self.encryption_key {
-      return V2Local(&strd_msg, self.footer.as_deref(), &mut enc_key);
-    } else if let Some(ed_key_pair) = self.ed_key {
-      return V2Public(&strd_msg, self.footer.as_deref(), &ed_key_pair);
-    } else {
-      return Err(GenericError::NoKeyProvided {})?;
-    }
+    return Err(GenericError::NoKeyProvided {})?;
   }
 }
 

--- a/src/tokens/builder.rs
+++ b/src/tokens/builder.rs
@@ -60,6 +60,13 @@ impl PasetoBuilder {
       }
     }
 
+    #[cfg(all(not(feature = "v2"), feature = "v1"))]
+    {
+      if let Some(mut enc_key) = self.encryption_key {
+        return V1Local(&strd_msg, self.footer.as_deref(), &mut enc_key);
+      }
+    }
+
     #[cfg(feature = "v2")]
     {
       if let Some(ed_key_pair) = self.ed_key {
@@ -166,12 +173,17 @@ impl PasetoBuilder {
 
 #[cfg(test)]
 mod unit_test {
+  #[cfg(feature = "v2")]
   use super::*;
+
+  #[cfg(feature = "v2")]
   use crate::v2::local::decrypt_paseto as V2Decrypt;
 
+  #[cfg(feature = "v2")]
   use serde_json::from_str as ParseJson;
 
   #[test]
+  #[cfg(feature = "v2")]
   fn can_construct_a_token() {
     let token = PasetoBuilder::new()
       .set_encryption_key(Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -11,8 +11,7 @@ use crate::v2::{decrypt_paseto as V2Decrypt, verify_paseto as V2Verify};
 use chrono::prelude::*;
 use failure::Error;
 #[cfg(feature = "v2")]
-use ring::signature::Ed25519KeyPair;
-use ring::signature::KeyPair;
+use ring::signature::{Ed25519KeyPair, KeyPair};
 use serde_json::{from_str as ParseJson, Value as JsonValue};
 
 pub mod builder;
@@ -145,9 +144,9 @@ pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Re
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
 #[cfg(all(feature = "v1", not(feature = "v2")))]
-pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Result<Jsonvalue, Error> {
+pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Result<JsonValue, Error> {
   let token = V1Decrypt(token, footer, key)?;
-  return validate_potential_json_blob(token);
+  return validate_potential_json_blob(&token);
 }
 
 /// Validate a local token for V2.
@@ -166,9 +165,9 @@ pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Re
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
 #[cfg(all(feature = "v2", not(feature = "v1")))]
-pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Result<Jsonvalue, Error> {
+pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Result<JsonValue, Error> {
   let token = V2Decrypt(token, footer, key)?;
-  return validate_potential_json_blob(token);
+  return validate_potential_json_blob(&token);
 }
 
 /// Validate a public token for V1, or V2.
@@ -186,6 +185,7 @@ pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Re
 ///
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
+#[cfg(all(feature = "v2", feature = "v1"))]
 pub fn validate_public_token(token: &str, footer: Option<&str>, key: &PasetoPublicKey) -> Result<JsonValue, Error> {
   if token.starts_with("v2.public.") {
     return match key {
@@ -228,13 +228,12 @@ pub fn validate_public_token(token: &str, footer: Option<&str>, key: &PasetoPubl
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
 #[cfg(all(feature = "v1", not(feature = "v2")))]
-pub fn validate_public_token(token: &str, footer: Option<&str>, key: &PasetoPublicKey) -> Result<Jsonvalue, Error> {
+pub fn validate_public_token(token: &str, footer: Option<&str>, key: &PasetoPublicKey) -> Result<JsonValue, Error> {
   return match key {
     PasetoPublicKey::RSAPublicKey(key_content) => {
       let internal_msg = V1Verify(token, footer, &key_content)?;
-      validate_potential_json_blob(internal_msg)
+      validate_potential_json_blob(&internal_msg)
     }
-    _ => Err(GenericError::NoKeyProvided {})?,
   };
 }
 
@@ -254,11 +253,11 @@ pub fn validate_public_token(token: &str, footer: Option<&str>, key: &PasetoPubl
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
 #[cfg(all(feature = "v2", not(feature = "v1")))]
-pub fn validate_public_token(token: String, footer: Option<&str>, key: &PasetoPublicKey) -> Result<Jsonvalue, Error> {
+pub fn validate_public_token(token: String, footer: Option<&str>, key: &PasetoPublicKey) -> Result<JsonValue, Error> {
   return match key {
     PasetoPublicKey::ED25519KeyPair(key_pair) => {
-      let internal_msg = V2Verify(token, footer, &key_pair)?;
-      validate_potential_json_blob(internal_msg)
+      let internal_msg = V2Verify(&token, footer, key_pair.public_key().as_ref())?;
+      validate_potential_json_blob(&internal_msg)
     }
     _ => Err(GenericError::NoKeyProvided {})?,
   };

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -115,59 +115,24 @@ pub fn validate_potential_json_blob(data: &str) -> Result<JsonValue, Error> {
 ///
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
-#[cfg(all(feature = "v1", feature = "v2"))]
 pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Result<JsonValue, Error> {
-  if token.starts_with("v2.local.") {
-    let message = V2Decrypt(token, footer, &key)?;
-    return validate_potential_json_blob(&message);
-  } else if token.starts_with("v1.local.") {
-    let message = V1Decrypt(token, footer, &key)?;
-    return validate_potential_json_blob(&message);
+  #[cfg(feature = "v2")]
+  {
+    if token.starts_with("v2.local.") {
+      let message = V2Decrypt(token, footer, &key)?;
+      return validate_potential_json_blob(&message);
+    }
+  }
+
+  #[cfg(feature = "v1")]
+  {
+    if token.starts_with("v1.local.") {
+      let message = V1Decrypt(token, footer, &key)?;
+      return validate_potential_json_blob(&message);
+    }
   }
 
   return Err(GenericError::InvalidToken {})?;
-}
-
-/// Validate a local token for V1.
-///
-/// This specifically validates:
-///   * issued_at
-///   * expired
-///   * not_before
-///
-/// This specifically does not validate:
-///   * audience
-///   * jti
-///   * issuedBy
-///   * subject
-///
-/// Because we validate these fields the resulting type must be a json object. If it's not
-/// please use the protocol impls directly.
-#[cfg(all(feature = "v1", not(feature = "v2")))]
-pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Result<JsonValue, Error> {
-  let token = V1Decrypt(token, footer, key)?;
-  return validate_potential_json_blob(&token);
-}
-
-/// Validate a local token for V2.
-///
-/// This specifically validates:
-///   * issued_at
-///   * expired
-///   * not_before
-///
-/// This specifically does not validate:
-///   * audience
-///   * jti
-///   * issuedBy
-///   * subject
-///
-/// Because we validate these fields the resulting type must be a json object. If it's not
-/// please use the protocol impls directly.
-#[cfg(all(feature = "v2", not(feature = "v1")))]
-pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Result<JsonValue, Error> {
-  let token = V2Decrypt(token, footer, key)?;
-  return validate_potential_json_blob(&token);
 }
 
 /// Validate a public token for V1, or V2.
@@ -185,88 +150,46 @@ pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Re
 ///
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
-#[cfg(all(feature = "v2", feature = "v1"))]
 pub fn validate_public_token(token: &str, footer: Option<&str>, key: &PasetoPublicKey) -> Result<JsonValue, Error> {
-  if token.starts_with("v2.public.") {
-    return match key {
-      PasetoPublicKey::ED25519KeyPair(key_pair) => {
-        let internal_msg = V2Verify(token, footer, key_pair.public_key().as_ref())?;
-        validate_potential_json_blob(&internal_msg)
-      }
-      PasetoPublicKey::ED25519PublicKey(pub_key_contents) => {
-        let internal_msg = V2Verify(token, footer, &pub_key_contents)?;
-        validate_potential_json_blob(&internal_msg)
-      }
-      _ => Err(GenericError::NoKeyProvided {})?,
-    };
-  } else if token.starts_with("v1.public.") {
-    return match key {
-      PasetoPublicKey::RSAPublicKey(key_content) => {
-        let internal_msg = V1Verify(token, footer, &key_content)?;
-        validate_potential_json_blob(&internal_msg)
-      }
-      _ => Err(GenericError::NoKeyProvided {})?,
-    };
+  #[cfg(feature = "v2")]
+  {
+    if token.starts_with("v2.public.") {
+      return match key {
+        PasetoPublicKey::ED25519KeyPair(key_pair) => {
+          let internal_msg = V2Verify(token, footer, key_pair.public_key().as_ref())?;
+          validate_potential_json_blob(&internal_msg)
+        }
+        PasetoPublicKey::ED25519PublicKey(pub_key_contents) => {
+          let internal_msg = V2Verify(token, footer, &pub_key_contents)?;
+          validate_potential_json_blob(&internal_msg)
+        }
+        #[cfg(feature = "v1")]
+        _ => Err(GenericError::NoKeyProvided {})?,
+      };
+    }
+  }
+
+  #[cfg(feature = "v1")]
+  {
+    if token.starts_with("v1.public.") {
+      return match key {
+        PasetoPublicKey::RSAPublicKey(key_content) => {
+          let internal_msg = V1Verify(token, footer, &key_content)?;
+          validate_potential_json_blob(&internal_msg)
+        }
+        #[cfg(feature = "v2")]
+        _ => Err(GenericError::NoKeyProvided {})?,
+      };
+    }
   }
 
   return Err(GenericError::InvalidToken {})?;
 }
 
-/// Validate a public token for V1.
-///
-/// This specifically validates:
-///   * issued_at
-///   * expired
-///   * not_before
-///
-/// This specifically does not validate:
-///   * audience
-///   * jti
-///   * issuedBy
-///   * subject
-///
-/// Because we validate these fields the resulting type must be a json object. If it's not
-/// please use the protocol impls directly.
-#[cfg(all(feature = "v1", not(feature = "v2")))]
-pub fn validate_public_token(token: &str, footer: Option<&str>, key: &PasetoPublicKey) -> Result<JsonValue, Error> {
-  return match key {
-    PasetoPublicKey::RSAPublicKey(key_content) => {
-      let internal_msg = V1Verify(token, footer, &key_content)?;
-      validate_potential_json_blob(&internal_msg)
-    }
-  };
-}
-
-/// Validate a public token for V2.
-///
-/// This specifically validates:
-///   * issued_at
-///   * expired
-///   * not_before
-///
-/// This specifically does not validate:
-///   * audience
-///   * jti
-///   * issuedBy
-///   * subject
-///
-/// Because we validate these fields the resulting type must be a json object. If it's not
-/// please use the protocol impls directly.
-#[cfg(all(feature = "v2", not(feature = "v1")))]
-pub fn validate_public_token(token: String, footer: Option<&str>, key: &PasetoPublicKey) -> Result<JsonValue, Error> {
-  return match key {
-    PasetoPublicKey::ED25519KeyPair(key_pair) => {
-      let internal_msg = V2Verify(&token, footer, key_pair.public_key().as_ref())?;
-      validate_potential_json_blob(&internal_msg)
-    }
-    _ => Err(GenericError::NoKeyProvided {})?,
-  };
-}
-
 #[cfg(test)]
 mod unit_tests {
   use super::*;
-
+  #[cfg(feature = "v2")]
   use ring::rand::SystemRandom;
   use serde_json::json;
 
@@ -325,6 +248,7 @@ mod unit_tests {
   }
 
   #[test]
+  #[cfg(feature = "v2")]
   fn valid_pub_token_passes_test() {
     let current_date_time = Utc::now();
     let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
@@ -353,6 +277,7 @@ mod unit_tests {
   }
 
   #[test]
+  #[cfg(feature = "v2")]
   fn validate_pub_key_only_v2() {
     let current_date_time = Utc::now();
     let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
@@ -385,6 +310,7 @@ mod unit_tests {
   }
 
   #[test]
+  #[cfg(feature = "v2")]
   fn invalid_pub_token_doesnt_validate() {
     let current_date_time = Utc::now();
     let dt = Utc.ymd(current_date_time.year() - 1, 7, 8).and_hms(9, 10, 11);


### PR DESCRIPTION
Note: this PR builds on #23 and provide a more feature-proof fix of the problem.

## Motivation ##

The source of #23 is that there was code duplication so fixes were only applied to one of the variants. 

This change move the conditional check for `v1` & `v2` in the builder inside the methods instead of duplicating them

## Test Plan (required) ##

I ran both `cargo build` and `cargo test` with/without `v1` & `v2` (There are still a few unused things warning when only one of them is present but they build and pass tests)