### PR TITLE
Add a benchmark suite based on criterion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,9 @@ serde_json = { version = "^1.0.0", optional = true }
 sodiumoxide = { version = "^0.2.2", optional = true }
 
 [dev-dependencies]
+criterion = "0.3"
 hex = "^0.4.0"
+
+[[bench]]
+name = "criterion_benches"
+harness = false

--- a/benches/criterion_benches/main.rs
+++ b/benches/criterion_benches/main.rs
@@ -1,0 +1,15 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+mod tokens;
+mod utils;
+mod pae;
+mod v2;
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+  tokens::benches(c);
+  pae::benches(c);
+  v2::benches(c);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/criterion_benches/pae.rs
+++ b/benches/criterion_benches/pae.rs
@@ -1,0 +1,16 @@
+use std::iter;
+use criterion::{black_box, Criterion, Bencher};
+
+use crate::utils::{bench_sized_string_group};
+
+fn bench_pae(b: &mut Bencher, s: &str, count: u64) {
+    let data = iter::repeat(Vec::from(s)).take(count as usize).collect::<Vec<_>>();
+    b.iter(|| {
+        paseto::pae::pae(black_box(data.clone()))
+    })
+}
+
+pub fn benches(c: &mut Criterion) {
+    bench_sized_string_group(c, "pae/x3", 3, &| b,s | { bench_pae(b, s, 3) });
+    bench_sized_string_group(c, "pae/x100", 100, &| b,s | { bench_pae(b, s, 100) });
+}

--- a/benches/criterion_benches/tokens/builder.rs
+++ b/benches/criterion_benches/tokens/builder.rs
@@ -1,0 +1,83 @@
+use std::str;
+use chrono::prelude::*;
+use serde_json::json;
+use criterion::{black_box, Criterion, Bencher};
+use paseto::tokens::builder::PasetoBuilder;
+use ring::rand::SystemRandom;
+use ring::signature::Ed25519KeyPair;
+
+use crate::utils::{bench_sized_string_group};
+
+fn bench_construct_local(b: &mut Bencher, s: &str) {
+  let claim = s;
+  let footer = s;
+  b.iter(|| {
+    PasetoBuilder::new()
+      .set_encryption_key(Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+      .set_issued_at(None)
+      .set_expiration(Utc::now())
+      .set_issuer(String::from("issuer"))
+      .set_audience(String::from("audience"))
+      .set_jti(String::from("jti"))
+      .set_not_before(Utc::now())
+      .set_subject(String::from("test"))
+      .set_claim(String::from("claim"), json!(black_box(claim)))
+      .set_footer(String::from(black_box(footer)))
+      .build()
+      .expect("Can't build local v1 token")
+  });
+}
+
+fn bench_construct_public_v1(b: &mut Bencher, s: &str) {
+  let claim = s;
+  let footer = s;
+
+  let private_key: &[u8] = include_bytes!("../../../src/v1/signature_rsa_example_private_key.der");
+
+  b.iter(|| {
+    PasetoBuilder::new()
+      .set_rsa_key(Vec::from(black_box(private_key)))
+      .set_issued_at(None)
+      .set_expiration(Utc::now())
+      .set_issuer(String::from("issuer"))
+      .set_audience(String::from("audience"))
+      .set_jti(String::from("jti"))
+      .set_not_before(Utc::now())
+      .set_subject(String::from("test"))
+      .set_claim(String::from("claim"), json!(black_box(claim)))
+      .set_footer(String::from(black_box(footer)))
+      .build()
+      .expect("Can't build public v1 token")
+  });
+}
+
+fn bench_construct_public_v2(b: &mut Bencher, s: &str) {
+  let claim = s;
+  let footer = s;
+
+  let sys_rand = SystemRandom::new();
+  let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+
+  b.iter(|| {
+    let key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+    PasetoBuilder::new()
+      .set_ed25519_key(key)
+      .set_issued_at(None)
+      .set_expiration(Utc::now())
+      .set_issuer(String::from("issuer"))
+      .set_audience(String::from("audience"))
+      .set_jti(String::from("jti"))
+      .set_not_before(Utc::now())
+      .set_subject(String::from("test"))
+      .set_claim(String::from("claim"), json!(black_box(claim)))
+      .set_footer(String::from(black_box(footer)))
+      .build()
+      .expect("Can't build public v1 token")
+  });
+}
+
+pub fn benches(c: &mut Criterion) {
+  bench_sized_string_group(c, "token::builder::local", 2, &bench_construct_local);
+  bench_sized_string_group(c, "token::builder::public_v1", 2, &bench_construct_public_v1);
+  bench_sized_string_group(c, "token::builder::public_v2", 2, &bench_construct_public_v2);
+}

--- a/benches/criterion_benches/tokens/mod.rs
+++ b/benches/criterion_benches/tokens/mod.rs
@@ -1,0 +1,130 @@
+use std::str;
+use chrono::prelude::*;
+use serde_json::json;
+use criterion::{black_box, Criterion, Bencher};
+use paseto::tokens::{
+  validate_local_token,
+  validate_public_token,
+  PasetoPublicKey,
+  builder::PasetoBuilder,
+};
+use ring::rand::SystemRandom;
+use ring::signature::Ed25519KeyPair;
+use ring::signature::KeyPair;
+
+use crate::utils::{bench_sized_string_group};
+
+mod builder;
+
+fn bench_validate_local(b: &mut Bencher, s: &str) {
+  let claim = s;
+  let footer = s;
+
+  let current_date_time = Utc::now();
+  let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+
+  let key = Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes());
+
+  let token = PasetoBuilder::new()
+    .set_encryption_key(key.clone())
+    .set_issued_at(None)
+    .set_expiration(dt)
+    .set_issuer(String::from("issuer"))
+    .set_audience(String::from("audience"))
+    .set_jti(String::from("jti"))
+    .set_not_before(Utc::now())
+    .set_subject(String::from("test"))
+    .set_claim(String::from("claim"), json!(claim))
+    .set_footer(String::from(footer))
+    .build()
+    .expect("Can't build local v1 token");
+
+  b.iter(|| {
+    validate_local_token(
+        black_box(&token),
+        Some(&black_box(footer)),
+        &key,
+      )
+      .expect("Failed to validate token!")
+  });
+}
+
+fn bench_validate_public_v1(b: &mut Bencher, s: &str) {
+  let claim = s;
+  let footer = s;
+
+  let current_date_time = Utc::now();
+  let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+  let private_key: &[u8] = include_bytes!("../../../src/v1/signature_rsa_example_private_key.der");
+  let public_key: &[u8] = include_bytes!("../../../src/v1/signature_rsa_example_public_key.der");
+
+  let token = PasetoBuilder::new()
+    .set_rsa_key(Vec::from(private_key))
+    .set_issued_at(None)
+    .set_expiration(dt)
+    .set_issuer(String::from("issuer"))
+    .set_audience(String::from("audience"))
+    .set_jti(String::from("jti"))
+    .set_not_before(Utc::now())
+    .set_subject(String::from("test"))
+    .set_claim(String::from("claim"), json!(black_box(claim)))
+    .set_footer(String::from(black_box(footer)))
+    .build()
+    .expect("Can't build public v1 token");
+
+  let public_key = PasetoPublicKey::RSAPublicKey(public_key.to_vec());
+
+  b.iter(|| {
+    validate_public_token(
+      black_box(&token),
+      Some(&black_box(footer)),
+      black_box(&public_key),
+    )
+    .expect("Failed to validate token!")
+  });
+}
+
+fn bench_validate_public_v2(b: &mut Bencher, s: &str) {
+  let claim = s;
+  let footer = s;
+
+  let current_date_time = Utc::now();
+  let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+  let sys_rand = SystemRandom::new();
+  let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+
+  let key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+  let token = PasetoBuilder::new()
+    .set_ed25519_key(key)
+    .set_issued_at(None)
+    .set_expiration(dt)
+    .set_issuer(String::from("issuer"))
+    .set_audience(String::from("audience"))
+    .set_jti(String::from("jti"))
+    .set_not_before(Utc::now())
+    .set_subject(String::from("test"))
+    .set_claim(String::from("claim"), json!(black_box(claim)))
+    .set_footer(String::from(black_box(footer)))
+    .build()
+    .expect("Can't build public v1 token");
+
+  let cloned_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+  let public_key = PasetoPublicKey::ED25519PublicKey(Vec::from(cloned_key.public_key().as_ref()));
+
+  b.iter(|| {
+    validate_public_token(
+      black_box(&token),
+      Some(&black_box(footer)),
+      black_box(&public_key),
+    )
+    .expect("Failed to validate token!")
+  });
+}
+
+pub fn benches(c: &mut Criterion) {
+  bench_sized_string_group(c, "token::validate::local", 2, &bench_validate_local);
+  bench_sized_string_group(c, "token::validate::public_v1", 2, &bench_validate_public_v1);
+  bench_sized_string_group(c, "token::validate::public_v2", 2, &bench_validate_public_v2);
+
+  builder::benches(c);
+}

--- a/benches/criterion_benches/utils.rs
+++ b/benches/criterion_benches/utils.rs
@@ -1,0 +1,21 @@
+use std::iter;
+use std::str;
+use criterion::{Criterion, Bencher, Throughput, BenchmarkId};
+
+static KB: usize = 1024;
+static BENCH_SIZES: [usize; 4] = [1, 1 * KB, 4 * KB, 16 * KB];
+
+/// Run multiple benchmarks with strings of growing size relevant for paseto usage
+pub fn bench_sized_string_group(c: &mut Criterion, name: &str, factor: u64, f: &dyn Fn(&mut Bencher, &str)) {
+    let mut group = c.benchmark_group(name);
+    for size in BENCH_SIZES.iter() {
+        group.throughput(Throughput::Bytes((*size as u64) * factor));
+        group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, &size| {
+          let bytes = iter::repeat(20u8).take(size).collect::<Vec<_>>();
+          let s = str::from_utf8(&bytes).unwrap();
+
+          f(b, s);
+        });
+    }
+    group.finish();
+  }

--- a/benches/criterion_benches/v2/local.rs
+++ b/benches/criterion_benches/v2/local.rs
@@ -1,0 +1,31 @@
+use criterion::{black_box, Criterion, Bencher};
+use paseto::v2::local;
+use crate::utils::{bench_sized_string_group};
+
+fn bench_sign(b: &mut Bencher, s: &str) {
+  let msg = s;
+  let footer = Some(s);
+  let key = "YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes();
+
+  b.iter(|| {
+    local::local_paseto(black_box(msg), black_box(footer), black_box(&key))
+      .expect("Couldn't generate v2 local paseto")
+  })
+}
+
+fn bench_verify(b: &mut Bencher, s: &str,) {
+  let msg = s;
+  let footer = Some(s);
+  let key = "YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes();
+  let token = local::local_paseto(msg, footer, &key).expect("Failed to generate token");
+
+  b.iter(|| {
+    local::decrypt_paseto(black_box(&token), black_box(footer), black_box(key))
+      .expect("Couldn't verify v2 local paseto")
+  })
+}
+
+pub fn benches(c: &mut Criterion) {
+    bench_sized_string_group(c, "v2::local::sign", 2, &bench_sign);
+    bench_sized_string_group(c, "v2::local::validate", 2, &bench_verify);
+}

--- a/benches/criterion_benches/v2/mod.rs
+++ b/benches/criterion_benches/v2/mod.rs
@@ -1,0 +1,9 @@
+use criterion::{Criterion};
+
+mod local;
+mod public;
+
+pub fn benches(c: &mut Criterion) {
+    local::benches(c);
+    public::benches(c);
+}

--- a/benches/criterion_benches/v2/public.rs
+++ b/benches/criterion_benches/v2/public.rs
@@ -1,0 +1,40 @@
+use criterion::{black_box, Criterion, Bencher};
+use paseto::v2::public;
+use ring::signature::{Ed25519KeyPair, KeyPair};
+use ring::rand::SystemRandom;
+use crate::utils::{bench_sized_string_group};
+
+fn bench_sign(b: &mut Bencher, s: &str) {
+  let msg = s;
+  let footer = Some(s);
+  let sys_rand = SystemRandom::new();
+  let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+  let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+
+  b.iter(|| {
+    public::public_paseto(black_box(msg), black_box(footer), black_box(&as_key))
+      .expect("Couldn't generate v2 public paseto")
+  })
+}
+
+fn bench_verify(b: &mut Bencher, s: &str,) {
+  let msg = s;
+  let footer = Some(s);
+  let sys_rand = SystemRandom::new();
+  let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+  let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+  let token = public::public_paseto(msg, footer, &as_key).expect("Failed to generate token");
+
+  let cloned_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+  let public_key = cloned_key.public_key().as_ref();
+
+  b.iter(|| {
+    public::verify_paseto(black_box(&token), black_box(footer), black_box(public_key))
+      .expect("Couldn't verify v2 public paseto")
+  })
+}
+
+pub fn benches(c: &mut Criterion) {
+    bench_sized_string_group(c, "v2::public::sign", 2, &bench_sign);
+    bench_sized_string_group(c, "v2::public::validate", 2, &bench_verify);
+}


### PR DESCRIPTION
## Motivation ##

I wanted to know the performance of each primitive, especially between local and public but also between the go and the rust version.

## Test Plan ##

`cargo bench` give the result of the new benches and was checked to run both under Windows and Linux (Via WSL)