### PR TITLE
std::error::Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * High-level functions like `validate_local_token` and `validate_public_token` now take the `key` by reference.
 * The reference to `key` passed as argument to `v1::public::public_paseto` is not longer taken as mutable.
+* Error types have been changed, all functions now return `errors::GenericError` and this type now implements `std::error::Error`.
 
 ## 1.0.7
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ easy_tokens = ["serde_json", "chrono"]
 [dependencies]
 base64 = "^0.11"
 chrono = { version = "^0.4", optional = true, features = ["serde"] }
-failure = "^0.1"
-failure_derive = "^0.1"
+thiserror = "1.0"
 openssl = { version = "~0.10.24", optional = true }
 ring = { version = "^0.16", features = ["std"] }
 serde_json = { version = "^1.0.0", optional = true }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,37 +1,48 @@
-use failure_derive::*;
+use thiserror::Error;
 
-#[derive(Debug, Fail)]
+#[derive(Error, Debug)]
 pub enum SodiumErrors {
-  #[fail(display = "invalid key size, needed: {} got: {}", size_needed, size_provided)]
-  InvalidKeySize { size_provided: usize, size_needed: usize },
-  #[fail(display = "invalid nonce size, needed: {} got: {}", size_needed, size_provided)]
-  InvalidNonceSize { size_provided: usize, size_needed: usize },
-  #[fail(display = "Invalid key for libsodium!")]
-  InvalidKey {},
-  #[fail(display = "Function call to C Sodium Failed.")]
-  FunctionError {},
-  #[fail(display = "Invalid Output Size specified")]
-  InvalidOutputSize {},
+  #[error("Invalid key for libsodium!")]
+  InvalidKey,
+  #[error("Function call to C Sodium Failed.")]
+  FunctionError,
 }
 
-#[derive(Debug, Fail)]
+#[derive(Error, Debug)]
 pub enum RsaKeyErrors {
-  #[fail(display = "Invalid RSA Key Provided")]
-  InvalidKey {},
-  #[fail(display = "Failed to generate signed RSA content")]
-  SignError {},
+  #[error("Invalid RSA Key Provided")]
+  InvalidKey(#[from] ring::error::KeyRejected),
+  #[error("Invalid modulus size, expected {} but got {}", expected, actual)]
+  InvalidModulusSize {
+    expected: usize,
+    actual: usize,
+  },
+  #[error("Failed to generate signed RSA content")]
+  SignError,
 }
 
-#[derive(Debug, Fail)]
+#[derive(Error, Debug)]
 pub enum GenericError {
-  #[fail(display = "No key of the correct type was provided")]
-  NoKeyProvided {},
-  #[fail(display = "This token is invalid, or expired.")]
-  InvalidToken {},
-  #[fail(display = "This token has an invalid footer.")]
-  InvalidFooter {},
-  #[fail(display = "Failed to generate enough random bytes.")]
-  RandomError {},
-  #[fail(display = "Failed to perform HKDF")]
-  BadHkdf {},
+  #[error("No key of the correct type was provided")]
+  NoKeyProvided,
+  #[error("This token is invalid, or expired.")]
+  InvalidToken,
+  #[error("This token has an invalid footer.")]
+  InvalidFooter,
+  #[error("Failed to generate enough random bytes.")]
+  RandomError,
+  #[error("Failed to perform HKDF")]
+  BadHkdf,
+  #[error("JSON serialization error: {0}")]
+  JsonSerializationError(#[from] serde_json::error::Error),
+  #[error("RSA key error: {0}")]
+  RsaKeyError(#[from] RsaKeyErrors),
+  #[error("Sodium error: {0}")]
+  SodiumErrors(#[from] SodiumErrors),
+  #[error("Invalid UTF-8: {0}")]
+  InvalidUtf8(#[from] std::string::FromUtf8Error),
+  #[error("Base64 decoding failed: {0}")]
+  Base64DecodeError(#[from] base64::DecodeError),
+  #[error("OpenSSL error: {0}")]
+  OpenSslError(#[from] openssl::error::ErrorStack),
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -2,12 +2,14 @@ use thiserror::Error;
 
 /// A trait to easily convert sodium errors that are of the unit type
 /// to `SodiumErrors::FunctionError`.
+#[cfg(feature = "v2")]
 pub(crate) trait SodiumResult<T> {
   /// Convert sodium errors that are of the unit type
   /// to `SodiumErrors::FunctionError`.
   fn map_sodium_err(self) -> Result<T, SodiumErrors>;
 }
 
+#[cfg(feature = "v2")]
 impl<T> SodiumResult<T> for Result<T, ()> {
   #[inline]
   fn map_sodium_err(self) -> Result<T, SodiumErrors> {
@@ -15,6 +17,7 @@ impl<T> SodiumResult<T> for Result<T, ()> {
   }
 }
 
+#[cfg(feature = "v2")]
 #[derive(Error, Debug)]
 pub enum SodiumErrors {
   #[error("Invalid key for libsodium!")]
@@ -23,6 +26,7 @@ pub enum SodiumErrors {
   FunctionError(()),
 }
 
+#[cfg(feature = "v1")]
 #[derive(Error, Debug)]
 pub enum RsaKeyErrors {
   #[error("Invalid RSA Key Provided")]
@@ -48,16 +52,20 @@ pub enum GenericError {
   RandomError(#[source] ring::error::Unspecified),
   #[error("Failed to perform HKDF")]
   BadHkdf(#[source] ring::error::Unspecified),
+  #[cfg(feature = "easy_tokens")]
   #[error("JSON serialization error: {0}")]
   JsonSerializationError(#[from] serde_json::error::Error),
+  #[cfg(feature = "v1")]
   #[error("RSA key error: {0}")]
   RsaKeyError(#[from] RsaKeyErrors),
+  #[cfg(feature = "v2")]
   #[error("Sodium error: {0}")]
   SodiumErrors(#[from] SodiumErrors),
   #[error("Invalid UTF-8: {0}")]
   InvalidUtf8(#[from] std::string::FromUtf8Error),
   #[error("Base64 decoding failed: {0}")]
   Base64DecodeError(#[from] base64::DecodeError),
+  #[cfg(feature = "v1")]
   #[error("OpenSSL error: {0}")]
   OpenSslError(#[from] openssl::error::ErrorStack),
 }

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -9,7 +9,6 @@ use crate::v1::{decrypt_paseto as V1Decrypt, verify_paseto as V1Verify};
 use crate::v2::{decrypt_paseto as V2Decrypt, verify_paseto as V2Verify};
 
 use chrono::prelude::*;
-use failure::Error;
 #[cfg(feature = "v2")]
 use ring::signature::Ed25519KeyPair;
 use ring::signature::KeyPair;
@@ -41,7 +40,7 @@ pub enum PasetoPublicKey {
 ///   * jti
 ///   * issuedBy
 ///   * subject
-pub fn validate_potential_json_blob(data: &str) -> Result<JsonValue, Error> {
+pub fn validate_potential_json_blob(data: &str) -> Result<JsonValue, GenericError> {
   let value: JsonValue = ParseJson(data)?;
 
   let validation = {
@@ -117,7 +116,7 @@ pub fn validate_potential_json_blob(data: &str) -> Result<JsonValue, Error> {
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
 #[cfg(all(feature = "v1", feature = "v2"))]
-pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Result<JsonValue, Error> {
+pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Result<JsonValue, GenericError> {
   if token.starts_with("v2.local.") {
     let message = V2Decrypt(token, footer, &key)?;
     return validate_potential_json_blob(&message);
@@ -186,7 +185,7 @@ pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Re
 ///
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
-pub fn validate_public_token(token: &str, footer: Option<&str>, key: &PasetoPublicKey) -> Result<JsonValue, Error> {
+pub fn validate_public_token(token: &str, footer: Option<&str>, key: &PasetoPublicKey) -> Result<JsonValue, GenericError> {
   if token.starts_with("v2.public.") {
     return match key {
       PasetoPublicKey::ED25519KeyPair(key_pair) => {

--- a/src/v1/public.rs
+++ b/src/v1/public.rs
@@ -27,10 +27,8 @@ pub fn public_paseto(msg: &str, footer: Option<&str>, key_pair: &RsaKeyPair) -> 
   let random = SystemRandom::new();
 
   let mut signed_msg = [0; 256];
-  let sign_res = key_pair.sign(&RSA_PSS_SHA384, &random, &pre_auth, &mut signed_msg);
-  if sign_res.is_err() {
-    return Err(RsaKeyErrors::SignError)?;
-  }
+  key_pair.sign(&RSA_PSS_SHA384, &random, &pre_auth, &mut signed_msg)
+    .map_err(RsaKeyErrors::SignError)?;
 
   let mut combined_vec = Vec::new();
   combined_vec.extend_from_slice(msg.as_bytes());
@@ -64,12 +62,12 @@ pub fn verify_paseto(token: &str, footer: Option<&str>, public_key: &[u8]) -> Re
 
   if has_provided_footer {
     if token_parts.len() < 4 {
-      return Err(GenericError::InvalidFooter {})?;
+      return Err(GenericError::InvalidFooter)?;
     }
     let footer_encoded = encode_config(footer_as_str.as_bytes(), URL_SAFE_NO_PAD);
 
     if ConstantTimeEquals(footer_encoded.as_bytes(), token_parts[3].as_bytes()).is_err() {
-      return Err(GenericError::InvalidFooter {})?;
+      return Err(GenericError::InvalidFooter)?;
     }
   }
 

--- a/src/v2/public.rs
+++ b/src/v2/public.rs
@@ -53,12 +53,12 @@ pub fn verify_paseto(token: &str, footer: Option<&str>, public_key: &[u8]) -> Re
 
   if has_provided_footer {
     if token_parts.len() < 4 {
-      return Err(GenericError::InvalidFooter {})?;
+      return Err(GenericError::InvalidFooter)?;
     }
     let footer_encoded = encode_config(footer_as_str.as_bytes(), URL_SAFE_NO_PAD);
 
     if ConstantTimeEquals(footer_encoded.as_bytes(), token_parts[3].as_bytes()).is_err() {
-      return Err(GenericError::InvalidFooter {})?;
+      return Err(GenericError::InvalidFooter)?;
     }
   }
 

--- a/src/v2/public.rs
+++ b/src/v2/public.rs
@@ -5,14 +5,13 @@ use crate::errors::GenericError;
 use crate::pae::pae;
 
 use base64::{decode_config, encode_config, URL_SAFE_NO_PAD};
-use failure::Error;
 use ring::constant_time::verify_slices_are_equal as ConstantTimeEquals;
 use ring::signature::{Ed25519KeyPair, UnparsedPublicKey, ED25519};
 
 /// Sign a "v2.public" paseto token.
 ///
 /// Returns a result of a string if signing was successful.
-pub fn public_paseto(msg: &str, footer: Option<&str>, key_pair: &Ed25519KeyPair) -> Result<String, Error> {
+pub fn public_paseto(msg: &str, footer: Option<&str>, key_pair: &Ed25519KeyPair) -> Result<String, GenericError> {
   let header = "v2.public.";
   let footer_frd = footer.unwrap_or("");
 
@@ -43,7 +42,7 @@ pub fn public_paseto(msg: &str, footer: Option<&str>, key_pair: &Ed25519KeyPair)
 /// Verifies a "v2.public" paseto token based on a given key pair.
 ///
 /// Returns the message if verification was successful, otherwise an Err().
-pub fn verify_paseto(token: &str, footer: Option<&str>, public_key: &[u8]) -> Result<String, Error> {
+pub fn verify_paseto(token: &str, footer: Option<&str>, public_key: &[u8]) -> Result<String, GenericError> {
   let token_parts = token.split(".").collect::<Vec<_>>();
   if token_parts.len() < 3 {
     return Err(GenericError::InvalidToken {})?;


### PR DESCRIPTION
## Motivation ##

Errors exposed are currently using the `failure` crate but recent Rust releases have stabilized `std::error::Error`, this PR is a proposal to change the errors to implement the standard trait using the derive implementation of the `thiserror` crate.

I also took the liberty to add a few more details to errors and refactor things to use `map_error`/`ok_or` and other functions a little more.

## Test Plan ##

Ran `cargo test`

## Discussion points ##

* I like the proposal of the `thiserror` crate because it's simply providing a derive and doesn't leak to consumers but If there are better ones...
* I can remove any of the "I too the liberty" part or split it in another PR at convenience, i'm just lazy and trying to avoid rebasing too often 😓
* And yes I know that i'm already creating conflicts with at least #24 and #19 🙄