### PR TITLE
Add support for the `time` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,16 @@ authors = [
 edition = "2018"
 
 [features]
-default = ["v1", "v2", "easy_tokens"]
+default = ["v1", "v2", "easy_tokens_chrono"]
 v1 = ["openssl"]
 v2 = ["sodiumoxide"]
-easy_tokens = ["serde_json", "chrono"]
+easy_tokens_chrono = ["serde_json", "chrono"]
+easy_tokens_time = ["serde_json", "time"]
 
 [dependencies]
 base64 = "^0.13"
 chrono = { version = "^0.4", optional = true, features = ["serde"] }
+time = { version = "^0.2", optional = true, features = ["serde"] }
 failure = "^0.1"
 failure_derive = "^0.1"
 openssl = { version = "~0.10.24", optional = true }

--- a/examples/local-using-builders.rs
+++ b/examples/local-using-builders.rs
@@ -1,36 +1,76 @@
 #[cfg(feature = "easy_tokens_chrono")]
-use {
-  chrono::prelude::*,
-  serde_json::json,
-};
+use chrono::prelude::*;
+#[cfg(feature = "easy_tokens_time")]
+use time::{Date, time, OffsetDateTime};
+#[cfg(any(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
+use serde_json::json;
 
 fn main() {
   #[cfg(feature = "easy_tokens_chrono")]
-  {
-    let current_date_time = Utc::now();
-    let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+  chrono_example();
 
-    let token = paseto::tokens::PasetoBuilder::new()
-      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-      .set_issued_at(None)
-      .set_expiration(&dt)
-      .set_issuer("instructure")
-      .set_audience("wizards")
-      .set_jti("gandalf0")
-      .set_not_before(&Utc::now())
-      .set_subject("gandalf")
-      .set_claim("go-to", json!("mordor"))
-      .set_footer("key-id:gandalf0")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
-    println!("{:?}", token);
+  #[cfg(feature = "easy_tokens_time")]
+  time_example();
+}
 
-    let verified_token = paseto::tokens::validate_local_token(
-      &token,
-      Some("key-id:gandalf0"),
-      &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
-    )
-    .expect("Failed to validate token!");
-    println!("{:?}", verified_token);
-  }
+#[cfg(feature = "easy_tokens_chrono")]
+fn chrono_example() {
+  let current_date_time = Utc::now();
+  let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+
+  let token = paseto::tokens::PasetoBuilder::new()
+    .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+    .set_issued_at(None)
+    .set_expiration(&dt)
+    .set_issuer("instructure")
+    .set_audience("wizards")
+    .set_jti("gandalf0")
+    .set_not_before(&Utc::now())
+    .set_subject("gandalf")
+    .set_claim("go-to", json!("mordor"))
+    .set_footer("key-id:gandalf0")
+    .build()
+    .expect("Failed to construct paseto token w/ builder!");
+  println!("{:?}", token);
+
+  let verified_token = paseto::tokens::validate_local_token(
+    &token,
+    Some("key-id:gandalf0"),
+    &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+    &paseto::tokens::TimeBackend::Chrono
+  )
+  .expect("Failed to validate token!");
+  println!("{:?}", verified_token);
+}
+
+#[cfg(feature = "easy_tokens_time")]
+fn time_example() {
+  let current_date_time = OffsetDateTime::now_utc();
+  let dt = Date::try_from_ymd(current_date_time.year(), 7, 8).unwrap()
+    .with_time(time!(09:10:11))
+    .assume_utc();
+
+  let token = paseto::tokens::PasetoBuilder::new()
+    .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+    .set_issued_at(None)
+    .set_expiration(&dt)
+    .set_issuer("instructure")
+    .set_audience("wizards")
+    .set_jti("gandalf0")
+    .set_not_before(&OffsetDateTime::now_utc())
+    .set_subject("gandalf")
+    .set_claim("go-to", json!("mordor"))
+    .set_footer("key-id:gandalf0")
+    .build()
+    .expect("Failed to construct paseto token w/ builder!");
+  println!("{:?}", token);
+
+  let verified_token = paseto::tokens::validate_local_token(
+    &token,
+    Some("key-id:gandalf0"),
+    &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+    &paseto::tokens::TimeBackend::Time
+  )
+  .expect("Failed to validate token!");
+  println!("{:?}", verified_token);
 }

--- a/examples/local-using-builders.rs
+++ b/examples/local-using-builders.rs
@@ -1,11 +1,11 @@
-#[cfg(feature = "easy_tokens")]
+#[cfg(feature = "easy_tokens_chrono")]
 use {
   chrono::prelude::*,
   serde_json::json,
 };
 
 fn main() {
-  #[cfg(feature = "easy_tokens")]
+  #[cfg(feature = "easy_tokens_chrono")]
   {
     let current_date_time = Utc::now();
     let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);

--- a/examples/public-using-builder.rs
+++ b/examples/public-using-builder.rs
@@ -1,43 +1,91 @@
-#[cfg(all(feature = "v2", feature = "easy_tokens_chrono"))]
+#[cfg(feature = "v2")]
 use {
-  chrono::prelude::*,
   ring::rand::SystemRandom,
   ring::signature::Ed25519KeyPair,
   serde_json::json,
 };
+#[cfg(all(feature = "v2", any(feature = "easy_tokens_chrono", feature = "easy_tokens_time")))]
+use serde_json::json;
+#[cfg(all(feature = "v2", feature = "easy_tokens_chrono"))]
+use chrono::prelude::*;
+#[cfg(all(feature = "v2", feature = "easy_tokens_time"))]
+use time::{Date, time, OffsetDateTime};
 
 fn main() {
   #[cfg(all(feature = "v2", feature = "easy_tokens_chrono"))]
-  {
-    let current_date_time = Utc::now();
-    let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+  chrono_example();
+  #[cfg(all(feature = "v2", feature = "easy_tokens_time"))]
+  time_example();
+}
 
-    let sys_rand = SystemRandom::new();
-    let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
-    let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+#[cfg(all(feature = "v2", feature = "easy_tokens_chrono"))]
+fn chrono_example() {
+  let current_date_time = Utc::now();
+  let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
 
-    let token = paseto::tokens::PasetoBuilder::new()
-      .set_ed25519_key(&as_key)
-      .set_issued_at(None)
-      .set_expiration(&dt)
-      .set_issuer("instructure")
-      .set_audience("wizards")
-      .set_jti("gandalf0")
-      .set_not_before(&Utc::now())
-      .set_subject("gandalf")
-      .set_claim("go-to", json!("mordor"))
-      .set_footer("key-id:gandalf0")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
-    println!("{:?}", token);
+  let sys_rand = SystemRandom::new();
+  let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+  let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
-    let verified_token = paseto::tokens::validate_public_token(
-      &token,
-      Some("key-id:gandalf0"),
+  let token = paseto::tokens::PasetoBuilder::new()
+    .set_ed25519_key(&as_key)
+    .set_issued_at(None)
+    .set_expiration(&dt)
+    .set_issuer("instructure")
+    .set_audience("wizards")
+    .set_jti("gandalf0")
+    .set_not_before(&Utc::now())
+    .set_subject("gandalf")
+    .set_claim("go-to", json!("mordor"))
+    .set_footer("key-id:gandalf0")
+    .build()
+    .expect("Failed to construct paseto token w/ builder!");
+  println!("{:?}", token);
+
+  let verified_token = paseto::tokens::validate_public_token(
+    &token,
+    Some("key-id:gandalf0"),
     &paseto::tokens::PasetoPublicKey::ED25519KeyPair(&as_key),
-    )
-    .expect("Failed to validate token!");
+    &paseto::tokens::TimeBackend::Chrono
+  )
+  .expect("Failed to validate token!");
 
-    println!("{:?}", verified_token);
-  }
+  println!("{:?}", verified_token);
+}
+
+#[cfg(all(feature = "v2", feature = "easy_tokens_time"))]
+fn time_example() {
+  let current_date_time = OffsetDateTime::now_utc();
+  let dt = Date::try_from_ymd(current_date_time.year(), 7, 8).unwrap()
+    .with_time(time!(09:10:11))
+    .assume_utc();
+
+  let sys_rand = SystemRandom::new();
+  let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+  let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+
+  let token = paseto::tokens::PasetoBuilder::new()
+    .set_ed25519_key(&as_key)
+    .set_issued_at(None)
+    .set_expiration(&dt)
+    .set_issuer("instructure")
+    .set_audience("wizards")
+    .set_jti("gandalf0")
+    .set_not_before(&OffsetDateTime::now_utc())
+    .set_subject("gandalf")
+    .set_claim("go-to", json!("mordor"))
+    .set_footer("key-id:gandalf0")
+    .build()
+    .expect("Failed to construct paseto token w/ builder!");
+  println!("{:?}", token);
+
+  let verified_token = paseto::tokens::validate_public_token(
+    &token,
+    Some("key-id:gandalf0"),
+    &paseto::tokens::PasetoPublicKey::ED25519KeyPair(&as_key),
+    &paseto::tokens::TimeBackend::Time
+  )
+  .expect("Failed to validate token!");
+
+  println!("{:?}", verified_token);
 }

--- a/examples/public-using-builder.rs
+++ b/examples/public-using-builder.rs
@@ -1,4 +1,4 @@
-#[cfg(all(feature = "v2", feature = "easy_tokens"))]
+#[cfg(all(feature = "v2", feature = "easy_tokens_chrono"))]
 use {
   chrono::prelude::*,
   ring::rand::SystemRandom,
@@ -7,7 +7,7 @@ use {
 };
 
 fn main() {
-  #[cfg(all(feature = "v2", feature = "easy_tokens"))]
+  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono"))]
   {
     let current_date_time = Utc::now();
     let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,9 +3,9 @@
 pub mod errors;
 pub mod pae;
 
-#[cfg(feature = "easy_tokens")]
+#[cfg(any(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
 pub mod tokens;
-#[cfg(feature = "easy_tokens")]
+#[cfg(any(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
 pub use self::tokens::*;
 #[cfg(feature = "v1")]
 pub mod v1;

--- a/src/tokens/builder.rs
+++ b/src/tokens/builder.rs
@@ -9,7 +9,10 @@ use crate::v1::public_paseto as V1Public;
 #[cfg(feature = "v2")]
 use crate::v2::{local_paseto as V2Local, public_paseto as V2Public};
 
+#[cfg(feature = "easy_tokens_chrono")]
 use chrono::prelude::*;
+#[cfg(feature = "easy_tokens_time")]
+use time::OffsetDateTime;
 use failure::Error;
 #[cfg(feature = "v2")]
 use ring::signature::Ed25519KeyPair;
@@ -139,15 +142,59 @@ impl<'a> PasetoBuilder<'a> {
   }
 
   /// Sets the expiration date for this token.
+  #[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
   pub fn set_expiration(&'a mut self, expiration: &DateTime<Utc>) -> &'a mut Self {
+    self.set_claim("exp", json!(expiration))
+  }
+
+  /// Sets the expiration date for this token.
+  #[cfg(all(feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
+  pub fn set_expiration(&'a mut self, expiration: &OffsetDateTime) -> &'a mut Self {
+    self.set_claim("exp", json!(expiration))
+  }
+
+  /// Sets the expiration date for this token.
+  #[cfg(all(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
+  pub fn set_expiration_chrono(&'a mut self, expiration: &DateTime<Utc>) -> &'a mut Self {
+    self.set_claim("exp", json!(expiration))
+  }
+
+  /// Sets the expiration date for this token.
+  #[cfg(all(feature = "easy_tokens_time", feature = "easy_tokens_time"))]
+  pub fn set_expiration_time(&'a mut self, expiration: &OffsetDateTime) -> &'a mut Self {
     self.set_claim("exp", json!(expiration))
   }
 
   /// Sets the time this token was issued at.
   ///
   /// issued_at defaults to: Utc::now();
+  #[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
   pub fn set_issued_at(&'a mut self, issued_at: Option<DateTime<Utc>>) -> &'a mut Self {
     self.set_claim("iat", json!(issued_at.unwrap_or(Utc::now())))
+  }
+
+  /// Sets the time this token was issued at.
+  ///
+  /// issued_at defaults to: OffsetDateTime::now_utc();
+  #[cfg(all(feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
+  pub fn set_issued_at(&'a mut self, issued_at: Option<OffsetDateTime>) -> &'a mut Self {
+    self.set_claim("iat", json!(issued_at.unwrap_or(OffsetDateTime::now_utc())))
+  }
+
+  /// Sets the time this token was issued at.
+  ///
+  /// issued_at defaults to: Utc::now();
+  #[cfg(all(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
+  pub fn set_issued_at_chrono(&'a mut self, issued_at: Option<DateTime<Utc>>) -> &'a mut Self {
+    self.set_claim("iat", json!(issued_at.unwrap_or(Utc::now())))
+  }
+
+  /// Sets the time this token was issued at.
+  ///
+  /// issued_at defaults to: OffsetDateTime::now_utc();
+  #[cfg(all(feature = "easy_tokens_time", feature = "easy_tokens_time"))]
+  pub fn set_issued_at_time(&'a mut self, issued_at: Option<OffsetDateTime>) -> &'a mut Self {
+    self.set_claim("iat", json!(issued_at.unwrap_or(OffsetDateTime::now_utc())))
   }
 
   /// Sets the issuer for this token.
@@ -161,7 +208,26 @@ impl<'a> PasetoBuilder<'a> {
   }
 
   /// Sets the not before time.
+  #[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
   pub fn set_not_before(&'a mut self, not_before: &DateTime<Utc>) -> &'a mut Self {
+    self.set_claim("nbf", json!(not_before))
+  }
+
+  /// Sets the not before time.
+  #[cfg(all(feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
+  pub fn set_not_before(&'a mut self, not_before: &OffsetDateTime) -> &'a mut Self {
+    self.set_claim("nbf", json!(not_before))
+  }
+
+  /// Sets the not before time.
+  #[cfg(all(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
+  pub fn set_not_before_chrono(&'a mut self, not_before: &DateTime<Utc>) -> &'a mut Self {
+    self.set_claim("nbf", json!(not_before))
+  }
+
+  /// Sets the not before time.
+  #[cfg(all(feature = "easy_tokens_time", feature = "easy_tokens_time"))]
+  pub fn set_not_before_time(&'a mut self, not_before: &OffsetDateTime) -> &'a mut Self {
     self.set_claim("nbf", json!(not_before))
   }
 

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -31,6 +31,13 @@ pub enum PasetoPublicKey<'a> {
   ED25519PublicKey(&'a [u8]),
 }
 
+/// Specifies which time crate will be used as backend for validating a token's
+/// datetimes, i.e. issued_at. The available backends are [`Chrono`] and [`Time`],
+/// the can be enabled via the features `easy_tokens_chrono` and `easy_tokens_time`.
+/// The default feature and backend is [`Chrono`].
+///
+/// [`Chrono`]: https://docs.rs/chrono/*/chrono/index.html
+/// [`Time`]: https://docs.rs/time/*/time/index.html
 pub enum TimeBackend {
   #[cfg(feature = "easy_tokens_chrono")]
   Chrono,

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -8,7 +8,10 @@ use crate::v1::{decrypt_paseto as V1Decrypt, verify_paseto as V1Verify};
 #[cfg(feature = "v2")]
 use crate::v2::{decrypt_paseto as V2Decrypt, verify_paseto as V2Verify};
 
+#[cfg(feature = "easy_tokens_chrono")]
 use chrono::prelude::*;
+#[cfg(feature = "easy_tokens_time")]
+use time::OffsetDateTime;
 use failure::Error;
 #[cfg(feature = "v2")]
 use ring::signature::{Ed25519KeyPair, KeyPair};
@@ -28,6 +31,13 @@ pub enum PasetoPublicKey<'a> {
   ED25519PublicKey(&'a [u8]),
 }
 
+pub enum TimeBackend {
+  #[cfg(feature = "easy_tokens_chrono")]
+  Chrono,
+  #[cfg(feature = "easy_tokens_time")]
+  Time
+}
+
 /// Validates a potential json data blob, returning a JsonValue.
 ///
 /// This specifically validates:
@@ -40,63 +50,78 @@ pub enum PasetoPublicKey<'a> {
 ///   * jti
 ///   * issuedBy
 ///   * subject
-pub fn validate_potential_json_blob(data: &str) -> Result<JsonValue, Error> {
+pub fn validate_potential_json_blob(data: &str, backend: &TimeBackend) -> Result<JsonValue, Error> {
   let value: JsonValue = ParseJson(data)?;
 
-  let validation = {
-    let issued_at_opt = value.get("iat");
-    let expired_opt = value.get("exp");
-    let not_before_opt = value.get("nbf");
+  match backend {
+    #[cfg(feature = "easy_tokens_chrono")]
+    TimeBackend::Chrono => {
+      let parsed_iat = value.get("iat").and_then(|issued_at| issued_at.as_str())
+        .ok_or(GenericError::InvalidToken {})
+        .and_then(|iat| iat.parse::<DateTime<Utc>>()
+          .map_err(|_| GenericError::InvalidToken {})
+        )?;
 
-    if let Some(issued_at) = issued_at_opt {
-      if let Some(iat) = issued_at.as_str() {
-        if let Ok(parsed_iat) = iat.parse::<DateTime<Utc>>() {
-          if parsed_iat > Utc::now() {
-            return Err(GenericError::InvalidToken {})?;
-          }
-        } else {
-          return Err(GenericError::InvalidToken {})?;
-        }
-      } else {
+      if parsed_iat > Utc::now() {
         return Err(GenericError::InvalidToken {})?;
       }
-    }
 
-    if let Some(expired) = expired_opt {
-      if let Some(exp) = expired.as_str() {
-        if let Ok(parsed_exp) = exp.parse::<DateTime<Utc>>() {
-          if parsed_exp < Utc::now() {
-            return Err(GenericError::InvalidToken {})?;
-          }
-        } else {
-          return Err(GenericError::InvalidToken {})?;
-        }
-      } else {
+      let parsed_exp = value.get("exp").and_then(|expired| expired.as_str())
+        .ok_or(GenericError::InvalidToken {})
+        .and_then(|exp| exp.parse::<DateTime<Utc>>()
+          .map_err(|_| GenericError::InvalidToken {})
+        )?;
+
+      if parsed_exp > Utc::now() {
         return Err(GenericError::InvalidToken {})?;
       }
-    }
 
-    if let Some(not_before) = not_before_opt {
-      if let Some(nbf) = not_before.as_str() {
-        if let Ok(parsed_nbf) = nbf.parse::<DateTime<Utc>>() {
-          if parsed_nbf > Utc::now() {
-            return Err(GenericError::InvalidToken {})?;
-          }
-        } else {
-          return Err(GenericError::InvalidToken {})?;
-        }
-      } else {
+      let parsed_nbf = value.get("nbf").and_then(|not_before| not_before.as_str())
+        .ok_or(GenericError::InvalidToken {})
+        .and_then(|nbf| nbf.parse::<DateTime<Utc>>()
+          .map_err(|_| GenericError::InvalidToken {})
+        )?;
+
+      if parsed_nbf > Utc::now() {
         return Err(GenericError::InvalidToken {})?;
       }
+
+      Ok(value)
     }
+    #[cfg(feature = "easy_tokens_time")]
+    TimeBackend::Time => {
+      let parsed_iat = value.get("iat").and_then(|issued_at| issued_at.as_str())
+        .ok_or(GenericError::InvalidToken {})
+        .and_then(|iat| OffsetDateTime::parse(iat, time::Format::Rfc3339)
+          .map_err(|_| GenericError::InvalidToken {})
+        )?;
 
-    Ok(())
-  };
+      if parsed_iat > OffsetDateTime::now_utc() {
+        return Err(GenericError::InvalidToken {})?;
+      }
 
-  if validation.is_err() {
-    validation.err().unwrap()
-  } else {
-    Ok(value)
+      let parsed_exp = value.get("exp").and_then(|expired| expired.as_str())
+        .ok_or(GenericError::InvalidToken {})
+        .and_then(|exp| OffsetDateTime::parse(exp, time::Format::Rfc3339)
+          .map_err(|_| GenericError::InvalidToken {})
+        )?;
+
+      if parsed_exp > OffsetDateTime::now_utc() {
+        return Err(GenericError::InvalidToken {})?;
+      }
+
+      let parsed_nbf = value.get("nbf").and_then(|not_before| not_before.as_str())
+        .ok_or(GenericError::InvalidToken {})
+        .and_then(|nbf| OffsetDateTime::parse(nbf, time::Format::Rfc3339)
+          .map_err(|_| GenericError::InvalidToken {})
+        )?;
+
+      if parsed_nbf > OffsetDateTime::now_utc() {
+        return Err(GenericError::InvalidToken {})?;
+      }
+
+      Ok(value)
+    }
   }
 }
 
@@ -115,12 +140,12 @@ pub fn validate_potential_json_blob(data: &str) -> Result<JsonValue, Error> {
 ///
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
-pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Result<JsonValue, Error> {
+pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8], backend: &TimeBackend) -> Result<JsonValue, Error> {
   #[cfg(feature = "v2")]
   {
     if token.starts_with("v2.local.") {
       let message = V2Decrypt(token, footer, &key)?;
-      return validate_potential_json_blob(&message);
+      return validate_potential_json_blob(&message, backend);
     }
   }
 
@@ -128,7 +153,7 @@ pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Re
   {
     if token.starts_with("v1.local.") {
       let message = V1Decrypt(token, footer, &key)?;
-      return validate_potential_json_blob(&message);
+      return validate_potential_json_blob(&message, backend);
     }
   }
 
@@ -150,18 +175,18 @@ pub fn validate_local_token(token: &str, footer: Option<&str>, key: &[u8]) -> Re
 ///
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
-pub fn validate_public_token(token: &str, footer: Option<&str>, key: &PasetoPublicKey) -> Result<JsonValue, Error> {
+pub fn validate_public_token(token: &str, footer: Option<&str>, key: &PasetoPublicKey, backend: &TimeBackend) -> Result<JsonValue, Error> {
   #[cfg(feature = "v2")]
   {
     if token.starts_with("v2.public.") {
       return match key {
         PasetoPublicKey::ED25519KeyPair(key_pair) => {
           let internal_msg = V2Verify(token, footer, key_pair.public_key().as_ref())?;
-          validate_potential_json_blob(&internal_msg)
+          validate_potential_json_blob(&internal_msg, backend)
         }
         PasetoPublicKey::ED25519PublicKey(pub_key_contents) => {
           let internal_msg = V2Verify(token, footer, &pub_key_contents)?;
-          validate_potential_json_blob(&internal_msg)
+          validate_potential_json_blob(&internal_msg, backend)
         }
         #[cfg(feature = "v1")]
         _ => Err(GenericError::NoKeyProvided {})?,
@@ -175,7 +200,7 @@ pub fn validate_public_token(token: &str, footer: Option<&str>, key: &PasetoPubl
       return match key {
         PasetoPublicKey::RSAPublicKey(key_content) => {
           let internal_msg = V1Verify(token, footer, &key_content)?;
-          validate_potential_json_blob(&internal_msg)
+          validate_potential_json_blob(&internal_msg, backend)
         }
         #[cfg(feature = "v2")]
         _ => Err(GenericError::NoKeyProvided {})?,
@@ -194,6 +219,7 @@ mod unit_tests {
   use serde_json::json;
 
   #[test]
+  #[cfg(feature = "easy_tokens_chrono")]
   fn valid_enc_token_passes_test() {
     let current_date_time = Utc::now();
     let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
@@ -216,11 +242,13 @@ mod unit_tests {
       &token,
       Some("footer"),
       &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+      TimeBackend::Chrono
     )
     .expect("Failed to validate token!");
   }
 
   #[test]
+  #[cfg(feature = "easy_tokens_chrono")]
   fn invalid_enc_token_doesnt_validate() {
     let current_date_time = Utc::now();
     let dt = Utc.ymd(current_date_time.year() - 1, 7, 8).and_hms(9, 10, 11);
@@ -242,13 +270,14 @@ mod unit_tests {
     assert!(validate_local_token(
       &token,
       Some("footer"),
-      &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()
+      &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+      TimeBackend::Chrono
     )
     .is_err());
   }
 
   #[test]
-  #[cfg(feature = "v2")]
+  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono"))]
   fn valid_pub_token_passes_test() {
     let current_date_time = Utc::now();
     let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
@@ -271,12 +300,17 @@ mod unit_tests {
       .build()
       .expect("Failed to construct paseto token w/ builder!");
 
-    validate_public_token(&token, Some("footer"), &PasetoPublicKey::ED25519KeyPair(&as_key))
-      .expect("Failed to validate token!");
+    validate_public_token(
+      &token,
+      Some("footer"),
+      &PasetoPublicKey::ED25519KeyPair(&as_key),
+      TimeBackend::Chrono
+    )
+    .expect("Failed to validate token!");
   }
 
   #[test]
-  #[cfg(feature = "v2")]
+  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono"))]
   fn validate_pub_key_only_v2() {
     let current_date_time = Utc::now();
     let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
@@ -303,12 +337,13 @@ mod unit_tests {
       &token,
       Some("footer"),
       &PasetoPublicKey::ED25519PublicKey(as_key.public_key().as_ref()),
+      TimeBackend::Chrono
     )
     .expect("Failed to validate token!");
   }
 
   #[test]
-  #[cfg(feature = "v2")]
+  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono"))]
   fn invalid_pub_token_doesnt_validate() {
     let current_date_time = Utc::now();
     let dt = Utc.ymd(current_date_time.year() - 1, 7, 8).and_hms(9, 10, 11);
@@ -331,6 +366,6 @@ mod unit_tests {
       .build()
       .expect("Failed to construct paseto token w/ builder!");
 
-    assert!(validate_public_token(&token, Some("footer"), &PasetoPublicKey::ED25519KeyPair(&as_key)).is_err());
+    assert!(validate_public_token(&token, Some("footer"), &PasetoPublicKey::ED25519KeyPair(&as_key), TimeBackend::Chrono).is_err());
   }
 }


### PR DESCRIPTION
This commit puts `chrono` behind a feature flag and adds `time` as an alternative to it.

One thing to note is, that i had to exclude https://github.com/Weasy666/paseto/blob/1b97dcb99565807e43057e96470a03472ed9ac46/src/tokens/mod.rs#L51 from being build, when both features `easy_token_chrono` and `easy_token_time` are activated, as there is no way to guess which time crate should be used to parse the json time.