### PR TITLE
fix expired bug, improve errors

### DIFF
--- a/examples/public-using-builder.rs
+++ b/examples/public-using-builder.rs
@@ -2,7 +2,6 @@
 use {
   ring::rand::SystemRandom,
   ring::signature::Ed25519KeyPair,
-  serde_json::json,
 };
 #[cfg(all(feature = "v2", any(feature = "easy_tokens_chrono", feature = "easy_tokens_time")))]
 use serde_json::json;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,9 +28,9 @@ pub enum GenericError {
   NoKeyProvided {},
   #[fail(display = "This token is invalid.")]
   InvalidToken {},
-  #[fail(display = "This token contains a claim with an unparseable date.")]
-  UnparseableTokenDate {},
-  #[fail(display = "This token contains an issued at date that is not in the past (IAT claim).")]
+  #[fail(display = "The claim: {}, has an invalid date", claim_name)]
+  UnparseableTokenDate { claim_name: &'static str },
+  #[fail(display = "This token has not yet been issued, the issued at claim (IAT) is in the future.")]
   InvalidIssuedAtToken {},
   #[fail(display = "This token is not valid yet (NBF claim).")]
   InvalidNotBeforeToken {},

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,8 +26,16 @@ pub enum RsaKeyErrors {
 pub enum GenericError {
   #[fail(display = "No key of the correct type was provided")]
   NoKeyProvided {},
-  #[fail(display = "This token is invalid, or expired.")]
+  #[fail(display = "This token is invalid.")]
   InvalidToken {},
+  #[fail(display = "This token contains a claim with an unparseable date.")]
+  UnparseableTokenDate {},
+  #[fail(display = "This token contains an issued at date that is not in the past (IAT claim).")]
+  InvalidIssuedAtToken {},
+  #[fail(display = "This token is not valid yet (NBF claim).")]
+  InvalidNotBeforeToken {},
+  #[fail(display = "This token is expired (EXP claim).")]
+  ExpiredToken {},
   #[fail(display = "This token has an invalid footer.")]
   InvalidFooter {},
   #[fail(display = "Failed to generate enough random bytes.")]

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -64,9 +64,9 @@ pub fn validate_potential_json_blob(data: &str, backend: &TimeBackend) -> Result
     #[cfg(feature = "easy_tokens_chrono")]
     TimeBackend::Chrono => {
       let parsed_iat = value.get("iat").and_then(|issued_at| issued_at.as_str())
-        .ok_or(GenericError::UnparseableTokenDate {})
+        .ok_or(GenericError::UnparseableTokenDate { claim_name: "iat" })
         .and_then(|iat| iat.parse::<DateTime<Utc>>()
-          .map_err(|_| GenericError::UnparseableTokenDate {})
+          .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "iat" })
         )?;
 
       if parsed_iat > Utc::now() {
@@ -74,9 +74,9 @@ pub fn validate_potential_json_blob(data: &str, backend: &TimeBackend) -> Result
       }
 
       let parsed_exp = value.get("exp").and_then(|expired| expired.as_str())
-        .ok_or(GenericError::UnparseableTokenDate {})
+        .ok_or(GenericError::UnparseableTokenDate { claim_name: "exp" })
         .and_then(|exp| exp.parse::<DateTime<Utc>>()
-          .map_err(|_| GenericError::UnparseableTokenDate {})
+          .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "exp" })
         )?;
 
       if parsed_exp < Utc::now() {
@@ -84,9 +84,9 @@ pub fn validate_potential_json_blob(data: &str, backend: &TimeBackend) -> Result
       }
 
       let parsed_nbf = value.get("nbf").and_then(|not_before| not_before.as_str())
-        .ok_or(GenericError::UnparseableTokenDate {})
+        .ok_or(GenericError::UnparseableTokenDate { claim_name: "nbf" })
         .and_then(|nbf| nbf.parse::<DateTime<Utc>>()
-          .map_err(|_| GenericError::UnparseableTokenDate {})
+          .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "nbf" })
         )?;
 
       if parsed_nbf > Utc::now() {

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -98,9 +98,9 @@ pub fn validate_potential_json_blob(data: &str, backend: &TimeBackend) -> Result
     #[cfg(feature = "easy_tokens_time")]
     TimeBackend::Time => {
       let parsed_iat = value.get("iat").and_then(|issued_at| issued_at.as_str())
-        .ok_or(GenericError::UnparseableTokenDate {})
+        .ok_or(GenericError::UnparseableTokenDate { claim_name: "iat" })
         .and_then(|iat| OffsetDateTime::parse(iat, time::Format::Rfc3339)
-          .map_err(|_| GenericError::UnparseableTokenDate {})
+          .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "iat" })
         )?;
 
       if parsed_iat > OffsetDateTime::now_utc() {
@@ -108,9 +108,9 @@ pub fn validate_potential_json_blob(data: &str, backend: &TimeBackend) -> Result
       }
 
       let parsed_exp = value.get("exp").and_then(|expired| expired.as_str())
-        .ok_or(GenericError::UnparseableTokenDate {})
+        .ok_or(GenericError::UnparseableTokenDate { claim_name: "exp" })
         .and_then(|exp| OffsetDateTime::parse(exp, time::Format::Rfc3339)
-          .map_err(|_| GenericError::UnparseableTokenDate {})
+          .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "exp" })
         )?;
 
       if parsed_exp < OffsetDateTime::now_utc() {
@@ -118,9 +118,9 @@ pub fn validate_potential_json_blob(data: &str, backend: &TimeBackend) -> Result
       }
 
       let parsed_nbf = value.get("nbf").and_then(|not_before| not_before.as_str())
-        .ok_or(GenericError::UnparseableTokenDate {})
+        .ok_or(GenericError::UnparseableTokenDate { claim_name: "nbf" })
         .and_then(|nbf| OffsetDateTime::parse(nbf, time::Format::Rfc3339)
-          .map_err(|_| GenericError::UnparseableTokenDate {})
+          .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "nbf" })
         )?;
 
       if parsed_nbf > OffsetDateTime::now_utc() {


### PR DESCRIPTION
While I was debugging #33 to fix the bug that an valid expiration date was rejected by `validate_local_token`, I decided that more clear errors help to debug why something is failing. This PR fixes one thing: the wrong comparison character was used `>` vs `<` and more errors are added to improve library usage experience.