### PR TITLE
version bump + allow not setting iat/nbf/exp in builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1+1.0.3
+
+* Fix mistake where token builder would incorrectly force `nbf`/`iat`/`exp` fields.
+
 ## 2.0.0+1.0.3
 
 * Change `pae::pae` to borrow a slice of slices (`&[&[u8]]`) instead of taking ownership of a `Vec<Vec<u8>>`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "paseto"
 description = "An alternative token format to JWT"
-version = "2.0.0+1.0.3"
+version = "2.0.1+1.0.3"
 repository = "https://github.com/instructure/paseto"
 license = "MIT"
 authors = [

--- a/examples/direct-protocol.rs
+++ b/examples/direct-protocol.rs
@@ -1,5 +1,6 @@
 fn main() {
   let key = "YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes();
+  #[cfg(feature = "v2")]
   let mut key_mut = Vec::from(key);
   let message = "This is a signed non-JSON message.";
   let footer = "key-id:gandalf0";

--- a/examples/public-using-builder.rs
+++ b/examples/public-using-builder.rs
@@ -4,7 +4,7 @@ use chrono::prelude::*;
 use serde_json::json;
 #[cfg(all(feature = "v2", feature = "easy_tokens_time"))]
 use time::{time, Date, OffsetDateTime};
-#[cfg(feature = "v2")]
+#[cfg(all(feature = "v2", any(feature = "easy_tokens_chrono", feature = "easy_tokens_time")))]
 use {ring::rand::SystemRandom, ring::signature::Ed25519KeyPair};
 
 fn main() {

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -63,89 +63,101 @@ pub fn validate_potential_json_blob(data: &str, backend: &TimeBackend) -> Result
   match backend {
     #[cfg(feature = "easy_tokens_chrono")]
     TimeBackend::Chrono => {
-      let parsed_iat = value
-        .get("iat")
-        .and_then(|issued_at| issued_at.as_str())
-        .ok_or(GenericError::UnparseableTokenDate { claim_name: "iat" })
-        .and_then(|iat| {
-          iat
-            .parse::<DateTime<Utc>>()
-            .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "iat" })
-        })?;
+      let iat_value = value.get("iat");
+      if iat_value.is_some() {
+        let parsed_iat = iat_value
+          .and_then(|issued_at| issued_at.as_str())
+          .ok_or(GenericError::UnparseableTokenDate { claim_name: "iat" })
+          .and_then(|iat| {
+            iat
+              .parse::<DateTime<Utc>>()
+              .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "iat" })
+          })?;
 
-      if parsed_iat > Utc::now() {
-        return Err(GenericError::InvalidIssuedAtToken {})?;
+        if parsed_iat > Utc::now() {
+          return Err(GenericError::InvalidIssuedAtToken {})?;
+        }
       }
 
-      let parsed_exp = value
-        .get("exp")
-        .and_then(|expired| expired.as_str())
-        .ok_or(GenericError::UnparseableTokenDate { claim_name: "exp" })
-        .and_then(|exp| {
-          exp
-            .parse::<DateTime<Utc>>()
-            .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "exp" })
-        })?;
+      let exp_value = value.get("exp");
+      if exp_value.is_some() {
+        let parsed_exp = exp_value
+          .and_then(|expired| expired.as_str())
+          .ok_or(GenericError::UnparseableTokenDate { claim_name: "exp" })
+          .and_then(|exp| {
+            exp
+              .parse::<DateTime<Utc>>()
+              .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "exp" })
+          })?;
 
-      if parsed_exp < Utc::now() {
-        return Err(GenericError::ExpiredToken {})?;
+        if parsed_exp < Utc::now() {
+          return Err(GenericError::ExpiredToken {})?;
+        }
       }
 
-      let parsed_nbf = value
-        .get("nbf")
-        .and_then(|not_before| not_before.as_str())
-        .ok_or(GenericError::UnparseableTokenDate { claim_name: "nbf" })
-        .and_then(|nbf| {
-          nbf
-            .parse::<DateTime<Utc>>()
-            .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "nbf" })
-        })?;
+      let nbf_value = value.get("nbf");
+      if nbf_value.is_some() {
+        let parsed_nbf = nbf_value
+          .and_then(|not_before| not_before.as_str())
+          .ok_or(GenericError::UnparseableTokenDate { claim_name: "nbf" })
+          .and_then(|nbf| {
+            nbf
+              .parse::<DateTime<Utc>>()
+              .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "nbf" })
+          })?;
 
-      if parsed_nbf > Utc::now() {
-        return Err(GenericError::InvalidNotBeforeToken {})?;
+        if parsed_nbf > Utc::now() {
+          return Err(GenericError::InvalidNotBeforeToken {})?;
+        }
       }
 
       Ok(value)
     }
     #[cfg(feature = "easy_tokens_time")]
     TimeBackend::Time => {
-      let parsed_iat = value
-        .get("iat")
-        .and_then(|issued_at| issued_at.as_str())
-        .ok_or(GenericError::UnparseableTokenDate { claim_name: "iat" })
-        .and_then(|iat| {
-          OffsetDateTime::parse(iat, time::Format::Rfc3339)
-            .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "iat" })
-        })?;
+      let iat_value = value.get("iat");
+      if iat_value.is_some() {
+        let parsed_iat = iat_value
+          .and_then(|issued_at| issued_at.as_str())
+          .ok_or(GenericError::UnparseableTokenDate { claim_name: "iat" })
+          .and_then(|iat| {
+            OffsetDateTime::parse(iat, time::Format::Rfc3339)
+              .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "iat" })
+          })?;
 
-      if parsed_iat > OffsetDateTime::now_utc() {
-        return Err(GenericError::InvalidIssuedAtToken {})?;
+        if parsed_iat > OffsetDateTime::now_utc() {
+          return Err(GenericError::InvalidIssuedAtToken {})?;
+        }
       }
 
-      let parsed_exp = value
-        .get("exp")
-        .and_then(|expired| expired.as_str())
-        .ok_or(GenericError::UnparseableTokenDate { claim_name: "exp" })
-        .and_then(|exp| {
-          OffsetDateTime::parse(exp, time::Format::Rfc3339)
-            .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "exp" })
-        })?;
+      let exp_value = value.get("exp");
+      if exp_value.is_some() {
+        let parsed_exp = exp_value
+          .and_then(|expired| expired.as_str())
+          .ok_or(GenericError::UnparseableTokenDate { claim_name: "exp" })
+          .and_then(|exp| {
+            OffsetDateTime::parse(exp, time::Format::Rfc3339)
+              .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "exp" })
+          })?;
 
-      if parsed_exp < OffsetDateTime::now_utc() {
-        return Err(GenericError::ExpiredToken {})?;
+        if parsed_exp < OffsetDateTime::now_utc() {
+          return Err(GenericError::ExpiredToken {})?;
+        }
       }
 
-      let parsed_nbf = value
-        .get("nbf")
-        .and_then(|not_before| not_before.as_str())
-        .ok_or(GenericError::UnparseableTokenDate { claim_name: "nbf" })
-        .and_then(|nbf| {
-          OffsetDateTime::parse(nbf, time::Format::Rfc3339)
-            .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "nbf" })
-        })?;
+      let nbf_value = value.get("nbf");
+      if nbf_value.is_some() {
+        let parsed_nbf = nbf_value
+          .and_then(|not_before| not_before.as_str())
+          .ok_or(GenericError::UnparseableTokenDate { claim_name: "nbf" })
+          .and_then(|nbf| {
+            OffsetDateTime::parse(nbf, time::Format::Rfc3339)
+              .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "nbf" })
+          })?;
 
-      if parsed_nbf > OffsetDateTime::now_utc() {
-        return Err(GenericError::InvalidNotBeforeToken {})?;
+        if parsed_nbf > OffsetDateTime::now_utc() {
+          return Err(GenericError::InvalidNotBeforeToken {})?;
+        }
       }
 
       Ok(value)
@@ -479,5 +491,20 @@ mod unit_tests {
       &TimeBackend::Chrono
     )
     .is_err());
+  }
+
+  #[test]
+  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
+  fn allows_validation_without_iat_exp_nbf() {
+    let key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let state = PasetoBuilder::new()
+      .set_encryption_key(key.as_bytes())
+      .build()
+      .expect("failed to construct paseto token");
+
+    assert!(
+      validate_local_token(&state, None, key.as_bytes(), &TimeBackend::Chrono).is_ok(),
+      "Failed to validate token without nbf/iat/exp is okay!"
+    );
   }
 }


### PR DESCRIPTION
fixes #37

## Motivation (required) ##

In the refactor adding in the `time` crate, the token builder silently required that the fields:

  - `nbf` (not before)
  - `iat` (Issued at)
  - `exp` (expired)

Had to ***all*** be set in order to be valid. Creating too strict of a validation sequence. It should only validate attributes that are present.

## Test Plan (required) ##

- Tests should pass (there is a new test added not adding any of these fields).
