### PR TITLE
v2.0.2, fix build, sodiumoxide -> rust-crypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.2+1.0.3
+
+* Migrate away from sodiumoxide as it has become less, and less maintained not
+  providing a stable secure base anymore. Migrate to supported rust-crypto
+  projects. `SodiumErrors` will keep it's name, but now represents these
+  replacements for "sodium".
+
 ## 2.0.1+1.0.3
 
 * Fix mistake where token builder would incorrectly force `nbf`/`iat`/`exp` fields.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "paseto"
 description = "An alternative token format to JWT"
-version = "2.0.1+1.0.3"
+version = "2.0.2+1.0.3"
 repository = "https://github.com/instructure/paseto"
 license = "MIT"
 authors = [
@@ -12,12 +12,14 @@ edition = "2018"
 [features]
 default = ["v1", "v2", "easy_tokens_chrono"]
 v1 = ["openssl"]
-v2 = ["sodiumoxide"]
+v2 = ["blake2", "chacha20poly1305"]
 easy_tokens_chrono = ["serde_json", "chrono"]
 easy_tokens_time = ["serde_json", "time"]
 
 [dependencies]
 base64 = "^0.13"
+blake2 = { version = "^0.9.1", optional = true }
+chacha20poly1305 = { version = "^0.8.0", optional = true }
 chrono = { version = "^0.4", optional = true, features = ["serde"] }
 time = { version = "^0.2", optional = true, features = ["serde"] }
 failure = "^0.1"
@@ -25,7 +27,6 @@ failure_derive = "^0.1"
 openssl = { version = "~0.10.24", optional = true }
 ring = { version = "^0.16", features = ["std"] }
 serde_json = { version = "^1.0.0", optional = true }
-sodiumoxide = { version = "^0.2.2", optional = true }
 
 [dev-dependencies]
 hex = "^0.4.0"


### PR DESCRIPTION
fixes #40 

## Motivation (required) ##

sodiumoxide was becoming defunct, and also introduced some breaking changes in minor updates so we've switched to rust-crypto libraries which provide the same primitives (while still being well seen). these libraries also happen to be in pure rust which should be great for people actually building our crate as it means less dependencies that need a C compiler.

sodiumerrors now correspond to rust-crypto errors.

## Test Plan (required) ##

- All tests continue to pass unmodified to validate no differences between the two algorithims.
- I have also manually validated every single example manually.
