### PR TITLE
Proposed additions to the builder implementation to make adding claims more flexible...

### DIFF
--- a/src/tokens/builder.rs
+++ b/src/tokens/builder.rs
@@ -133,6 +133,31 @@ impl<'a> PasetoBuilder<'a> {
     self
   }
 
+  /// Sets multiple arbitrary claims by passing a HashMap of keys and values (keys inside the json token).
+  /// If a key in our passed map already exists in the internal claims, the value will be updated
+  /// with the value of the key in the HashMap we pass in this method.
+  /// For more info, reference the std::iter::Extend trait documentaton at
+  /// https://doc.rust-lang.org/std/iter/trait.Extend.html
+  pub fn set_claims(&'a mut self, claims: HashMap<&'a str, Value>) -> &'a mut Self {
+    self.extra_claims.extend(claims);
+    self
+  }
+
+  /// Sets multiple arbitrary claims by passing a closure that returns a HashMap of
+  /// keys and values (keys inside the json token).
+  /// If a key in our passed map already exists in the internal claims, the value will be updated
+  /// with the value of the key in the HashMap we pass in this method.
+  /// For more info, reference the std::iter::Extend trait documentaton at
+  /// https://doc.rust-lang.org/std/iter/trait.Extend.html
+  pub fn set_claims_by_closure<F>(&'a mut self, claims_closure: F) -> &'a mut Self
+  where
+    F: Fn() -> HashMap<&'a str, Value>,
+  {
+    let claims = claims_closure();
+    self.extra_claims.extend(claims);
+    self
+  }
+
   /// Sets an arbitrary claim (a key inside the json token).
   pub fn set_claim(&'a mut self, key: &'a str, value: Value) -> &'a mut Self {
     self.extra_claims.insert(key, value);
@@ -244,6 +269,95 @@ impl<'a> PasetoBuilder<'a> {
 mod unit_test {
   #[cfg(feature = "v2")]
   use {super::*, crate::v2::local::decrypt_paseto as V2Decrypt, serde_json::from_str as ParseJson};
+
+  #[test]
+  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
+  fn can_construct_a_token_chrono_with_claims_closure() {
+    //create a closure to dynamically set or get a map of
+    //any number of claims.  this could potentially
+    //come from a data store or some other service
+    let potentially_expesive_closure = || {
+      let mut arbitrary_claims = HashMap::new();
+      arbitrary_claims.insert("claim1", json!("data1"));
+      arbitrary_claims.insert("claim2", json!("data2"));
+      arbitrary_claims.insert("claim3", json!("data3"));
+      arbitrary_claims.insert("claim4", json!("data4"));
+      arbitrary_claims.insert("claim5", json!("data5"));
+      arbitrary_claims
+    };
+
+    let token = PasetoBuilder::new()
+      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+      .set_issued_at(None)
+      .set_expiration(&Utc::now())
+      .set_issuer("issuer")
+      .set_audience("audience")
+      .set_jti("jti")
+      .set_not_before(&Utc::now())
+      .set_subject("test")
+      .set_claims_by_closure(potentially_expesive_closure)
+      .set_footer("footer")
+      .build()
+      .expect("Failed to construct paseto token w/ builder!");
+
+    let decrypted_token = V2Decrypt(
+      &token,
+      Some("footer"),
+      &mut Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
+    )
+    .expect("Failed to decrypt token constructed with builder!");
+
+    let parsed: Value = ParseJson(&decrypted_token).expect("Failed to parse finalized token as json!");
+
+    assert!(parsed.get("claim1").is_some());
+    assert!(parsed.get("claim2").is_some());
+    assert!(parsed.get("claim3").is_some());
+    assert!(parsed.get("claim4").is_some());
+    assert!(parsed.get("claim5").is_some());
+    assert!(parsed.get("claim6").is_none());
+  }
+
+  #[test]
+  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
+  fn can_construct_a_token_chrono_with_claims_hashmap() {
+    //set or get a map of any number of claims
+    let mut arbitrary_claims = HashMap::new();
+    arbitrary_claims.insert("claim1", json!("data1"));
+    arbitrary_claims.insert("claim2", json!("data2"));
+    arbitrary_claims.insert("claim3", json!("data3"));
+    arbitrary_claims.insert("claim4", json!("data4"));
+    arbitrary_claims.insert("claim5", json!("data5"));
+
+    let token = PasetoBuilder::new()
+      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+      .set_issued_at(None)
+      .set_expiration(&Utc::now())
+      .set_issuer("issuer")
+      .set_audience("audience")
+      .set_jti("jti")
+      .set_not_before(&Utc::now())
+      .set_subject("test")
+      .set_claims(arbitrary_claims)
+      .set_footer("footer")
+      .build()
+      .expect("Failed to construct paseto token w/ builder!");
+
+    let decrypted_token = V2Decrypt(
+      &token,
+      Some("footer"),
+      &mut Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
+    )
+    .expect("Failed to decrypt token constructed with builder!");
+
+    let parsed: Value = ParseJson(&decrypted_token).expect("Failed to parse finalized token as json!");
+
+    assert!(parsed.get("claim1").is_some());
+    assert!(parsed.get("claim2").is_some());
+    assert!(parsed.get("claim3").is_some());
+    assert!(parsed.get("claim4").is_some());
+    assert!(parsed.get("claim5").is_some());
+    assert!(parsed.get("claim6").is_none());
+  }
 
   #[test]
   #[cfg(all(feature = "v2", feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]


### PR DESCRIPTION
## Motivation (required) ##

What existing problem does the pull request solve?

Hi, thanks for this great Paseto implementation.  One issue which frustrated me when using the builder is that I need to add additional claims one at a time using the `set_claim` method.  This requires each individual specific claim to be known when using the builder to assemble a token.  In order to make my code as reusable as possible, and potentially buried within a crate or bin of its own, I need to be able to dynamically inject an arbitrary list of claims I want to include from elsewhere.  To do so, I've added two new methods to use either in place of or in conjunction with the `set_claim` method.  The first simply pluralizes the method and is called `set_claims` and receives as an input a HashMap of Values to extend the existing internal `extra_claims` attribute of the builder.  the `std::iter::Extend` trait is used to merge the values into the existing HashMap.  The second method is named `set_claims_by_closure` and does the same as the `set_claims` method however instead of receiving a HashMap as an input to extend, it receives a closure which returns a HashMap and is then used to extend the internal HashMap.

## Test Plan (required) ##

I"ve added a test for each method:
1can_construct_a_token_chrono_with_claims_closure()`
1can_construct_a_token_chrono_with_claims_hashmap()`
For each, I've essentially just copied the `can_construct_a_token_chrono()` test and updated how the claims are created and set, and then verified they existed after the token was decrypted.

All tests currently pass.

Thanks for your consideration. 