### PR TITLE
move to thiserror, use clippy, update formatting rules

### DIFF
--- a/.azure-pipelines/linux-merge.yml
+++ b/.azure-pipelines/linux-merge.yml
@@ -16,7 +16,8 @@ variables: []
 steps:
   - script: |
       cargo fmt --all -- --check
-    displayName: Validate formatting
+      cargo clippy -- -W clippy::pedantic -D warnings
+    displayName: Validate formatting && Lint
   - script: |
       cargo test --no-default-features --features "v1"
       cargo test --no-default-features --features "v2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "paseto"
 description = "An alternative token format to JWT"
-version = "2.0.2+1.0.3"
+version = "3.0.0+1.0.3"
 repository = "https://github.com/instructure/paseto"
 license = "MIT"
 authors = [
@@ -21,12 +21,11 @@ base64 = "^0.13"
 blake2 = { version = "^0.9.2", optional = true }
 chacha20poly1305 = { version = "^0.9.0", optional = true }
 chrono = { version = "^0.4", optional = true, features = ["serde"] }
-time = { version = "^0.3", optional = true, features = ["serde-human-readable"] }
-failure = "^0.1"
-failure_derive = "^0.1"
 openssl = { version = "~0.10.36", optional = true }
 ring = { version = "^0.16", features = ["std"] }
 serde_json = { version = "^1.0.68", optional = true }
+time = { version = "^0.3", optional = true, features = ["serde-human-readable"] }
+thiserror = "^1.0.29"
 
 [dev-dependencies]
 hex = "^0.4.3"

--- a/examples/direct-protocol.rs
+++ b/examples/direct-protocol.rs
@@ -1,41 +1,44 @@
 fn main() {
-  let key = "YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes();
-  #[cfg(feature = "v2")]
-  let mut key_mut = Vec::from(key);
-  let message = "This is a signed non-JSON message.";
-  let footer = "key-id:gandalf0";
+	let key = "YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes();
+	#[cfg(feature = "v2")]
+	let mut key_mut = Vec::from(key);
+	let message = "This is a signed non-JSON message.";
+	let footer = "key-id:gandalf0";
 
-  #[cfg(feature = "v1")]
-  {
-    // Version 1
-    let v1_token =
-      paseto::v1::local::local_paseto(&message, None, key).expect("Failed to encrypt V1 Token sans footer.");
-    println!("{:?}", v1_token);
-    let decrypted_v1_token =
-      paseto::v1::local::decrypt_paseto(&v1_token, None, key).expect("Failed to decrypt V1 Token sans footer.");
-    println!("{:?}", decrypted_v1_token);
-    let v1_footer_token =
-      paseto::v1::local::local_paseto(&message, Some(&footer), key).expect("Failed to encrypt V1 Token.");
-    println!("{:?}", v1_footer_token);
-    let decrypted_v1_footer_token =
-      paseto::v1::local::decrypt_paseto(&v1_footer_token, Some(&footer), key).expect("Failed to decrypt V1 Token.");
-    println!("{:?}", decrypted_v1_footer_token);
-  }
+	#[cfg(feature = "v1")]
+	{
+		// Version 1
+		let v1_token = paseto::v1::local::local_paseto(&message, None, key)
+			.expect("Failed to encrypt V1 Token sans footer.");
+		println!("{:?}", v1_token);
+		let decrypted_v1_token = paseto::v1::local::decrypt_paseto(&v1_token, None, key)
+			.expect("Failed to decrypt V1 Token sans footer.");
+		println!("{:?}", decrypted_v1_token);
+		let v1_footer_token = paseto::v1::local::local_paseto(&message, Some(&footer), key)
+			.expect("Failed to encrypt V1 Token.");
+		println!("{:?}", v1_footer_token);
+		let decrypted_v1_footer_token =
+			paseto::v1::local::decrypt_paseto(&v1_footer_token, Some(&footer), key)
+				.expect("Failed to decrypt V1 Token.");
+		println!("{:?}", decrypted_v1_footer_token);
+	}
 
-  #[cfg(feature = "v2")]
-  {
-    // Version 2
-    let v2_token =
-      paseto::v2::local::local_paseto(&message, None, &mut key_mut).expect("Failed to encrypt V2 Token sans footer.");
-    println!("{:?}", v2_token);
-    let decrypted_v2_token = paseto::v2::local::decrypt_paseto(&v2_token, None, &mut key_mut)
-      .expect("Failed to decrypt V2 Token sans footer.");
-    println!("{:?}", decrypted_v2_token);
-    let v2_footer_token =
-      paseto::v2::local::local_paseto(&message, Some(&footer), &mut key_mut).expect("Failed to encrypt V2 Token.");
-    println!("{:?}", v2_footer_token);
-    let decrypted_v2_footer = paseto::v2::local::decrypt_paseto(&v2_footer_token, Some(&footer), &mut key_mut)
-      .expect("Failed to decrypt V2 Token.");
-    println!("{:?}", decrypted_v2_footer);
-  }
+	#[cfg(feature = "v2")]
+	{
+		// Version 2
+		let v2_token = paseto::v2::local::local_paseto(&message, None, &mut key_mut)
+			.expect("Failed to encrypt V2 Token sans footer.");
+		println!("{:?}", v2_token);
+		let decrypted_v2_token = paseto::v2::local::decrypt_paseto(&v2_token, None, &mut key_mut)
+			.expect("Failed to decrypt V2 Token sans footer.");
+		println!("{:?}", decrypted_v2_token);
+		let v2_footer_token =
+			paseto::v2::local::local_paseto(&message, Some(&footer), &mut key_mut)
+				.expect("Failed to encrypt V2 Token.");
+		println!("{:?}", v2_footer_token);
+		let decrypted_v2_footer =
+			paseto::v2::local::decrypt_paseto(&v2_footer_token, Some(&footer), &mut key_mut)
+				.expect("Failed to decrypt V2 Token.");
+		println!("{:?}", decrypted_v2_footer);
+	}
 }

--- a/examples/local-using-builders.rs
+++ b/examples/local-using-builders.rs
@@ -6,149 +6,153 @@ use serde_json::json;
 use time::{Date, OffsetDateTime, Time};
 
 fn main() {
-  #[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  chrono_example();
+	#[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
+	chrono_example();
 
-  #[cfg(all(feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
-  time_example();
+	#[cfg(all(feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
+	time_example();
 
-  #[cfg(all(feature = "easy_tokens_time", feature = "easy_tokens_chrono"))]
-  chrono_and_time_example();
+	#[cfg(all(feature = "easy_tokens_time", feature = "easy_tokens_chrono"))]
+	chrono_and_time_example();
 }
 
 #[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
 fn chrono_example() {
-  let current_date_time = Utc::now();
-  let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+	let current_date_time = Utc::now();
+	let dt = Utc
+		.ymd(current_date_time.year() + 1, 7, 8)
+		.and_hms(9, 10, 11);
 
-  let token = paseto::tokens::PasetoBuilder::new()
-    .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-    .set_issued_at(None)
-    .set_expiration(&dt)
-    .set_issuer("instructure")
-    .set_audience("wizards")
-    .set_jti("gandalf0")
-    .set_not_before(&Utc::now())
-    .set_subject("gandalf")
-    .set_claim("go-to", json!("mordor"))
-    .set_footer("key-id:gandalf0")
-    .build()
-    .expect("Failed to construct paseto token w/ builder!");
-  println!("{:?}", token);
+	let token = paseto::tokens::PasetoBuilder::new()
+		.set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+		.set_issued_at(None)
+		.set_expiration(&dt)
+		.set_issuer("instructure")
+		.set_audience("wizards")
+		.set_jti("gandalf0")
+		.set_not_before(&Utc::now())
+		.set_subject("gandalf")
+		.set_claim("go-to", json!("mordor"))
+		.set_footer("key-id:gandalf0")
+		.build()
+		.expect("Failed to construct paseto token w/ builder!");
+	println!("{:?}", token);
 
-  let verified_token = paseto::tokens::validate_local_token(
-    &token,
-    Some("key-id:gandalf0"),
-    &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
-    &paseto::tokens::TimeBackend::Chrono,
-  )
-  .expect("Failed to validate token!");
-  println!("{:?}", verified_token);
+	let verified_token = paseto::tokens::validate_local_token(
+		&token,
+		Some("key-id:gandalf0"),
+		&"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+		&paseto::tokens::TimeBackend::Chrono,
+	)
+	.expect("Failed to validate token!");
+	println!("{:?}", verified_token);
 }
 
 #[cfg(all(feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
 fn time_example() {
-  let current_date_time = OffsetDateTime::now_utc();
-  let dt = Date::from_calendar_date(
-    current_date_time.year() + 1,
-    current_date_time.month(),
-    current_date_time.day(),
-  )
-  .unwrap()
-  .with_time(Time::from_hms(09, 10, 11).expect("Failed to create time 09:10:11"))
-  .assume_utc();
+	let current_date_time = OffsetDateTime::now_utc();
+	let dt = Date::from_calendar_date(
+		current_date_time.year() + 1,
+		current_date_time.month(),
+		current_date_time.day(),
+	)
+	.unwrap()
+	.with_time(Time::from_hms(09, 10, 11).expect("Failed to create time 09:10:11"))
+	.assume_utc();
 
-  let token = paseto::tokens::PasetoBuilder::new()
-    .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-    .set_issued_at(None)
-    .set_expiration(&dt)
-    .set_issuer("instructure")
-    .set_audience("wizards")
-    .set_jti("gandalf0")
-    .set_not_before(&OffsetDateTime::now_utc())
-    .set_subject("gandalf")
-    .set_claim("go-to", json!("mordor"))
-    .set_footer("key-id:gandalf0")
-    .build()
-    .expect("Failed to construct paseto token w/ builder!");
-  println!("{:?}", token);
+	let token = paseto::tokens::PasetoBuilder::new()
+		.set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+		.set_issued_at(None)
+		.set_expiration(&dt)
+		.set_issuer("instructure")
+		.set_audience("wizards")
+		.set_jti("gandalf0")
+		.set_not_before(&OffsetDateTime::now_utc())
+		.set_subject("gandalf")
+		.set_claim("go-to", json!("mordor"))
+		.set_footer("key-id:gandalf0")
+		.build()
+		.expect("Failed to construct paseto token w/ builder!");
+	println!("{:?}", token);
 
-  let verified_token = paseto::tokens::validate_local_token(
-    &token,
-    Some("key-id:gandalf0"),
-    &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
-    &paseto::tokens::TimeBackend::Time,
-  )
-  .expect("Failed to validate token!");
-  println!("{:?}", verified_token);
+	let verified_token = paseto::tokens::validate_local_token(
+		&token,
+		Some("key-id:gandalf0"),
+		&"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+		&paseto::tokens::TimeBackend::Time,
+	)
+	.expect("Failed to validate token!");
+	println!("{:?}", verified_token);
 }
 
 #[cfg(all(feature = "easy_tokens_time", feature = "easy_tokens_chrono"))]
 fn chrono_and_time_example() {
-  {
-    println!("Using Time Crate:");
-    let current_date_time = OffsetDateTime::now_utc();
-    let dt = Date::from_calendar_date(
-      current_date_time.year() + 1,
-      current_date_time.month(),
-      current_date_time.day(),
-    )
-    .unwrap()
-    .with_time(Time::from_hms(09, 10, 11).expect("Failed to parse time 09:10:11"))
-    .assume_utc();
+	{
+		println!("Using Time Crate:");
+		let current_date_time = OffsetDateTime::now_utc();
+		let dt = Date::from_calendar_date(
+			current_date_time.year() + 1,
+			current_date_time.month(),
+			current_date_time.day(),
+		)
+		.unwrap()
+		.with_time(Time::from_hms(09, 10, 11).expect("Failed to parse time 09:10:11"))
+		.assume_utc();
 
-    let token = paseto::tokens::PasetoBuilder::new()
-      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-      .set_issued_at_time(None)
-      .set_expiration_time(&dt)
-      .set_issuer("instructure")
-      .set_audience("wizards")
-      .set_jti("gandalf0")
-      .set_not_before_time(&OffsetDateTime::now_utc())
-      .set_subject("gandalf")
-      .set_claim("go-to", json!("mordor"))
-      .set_footer("key-id:gandalf0")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
-    println!("{:?}", token);
+		let token = paseto::tokens::PasetoBuilder::new()
+			.set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+			.set_issued_at_time(None)
+			.set_expiration_time(&dt)
+			.set_issuer("instructure")
+			.set_audience("wizards")
+			.set_jti("gandalf0")
+			.set_not_before_time(&OffsetDateTime::now_utc())
+			.set_subject("gandalf")
+			.set_claim("go-to", json!("mordor"))
+			.set_footer("key-id:gandalf0")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
+		println!("{:?}", token);
 
-    let verified_token = paseto::tokens::validate_local_token(
-      &token,
-      Some("key-id:gandalf0"),
-      &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
-      &paseto::tokens::TimeBackend::Time,
-    )
-    .expect("Failed to validate token!");
-    println!("{:?}", verified_token);
-  }
+		let verified_token = paseto::tokens::validate_local_token(
+			&token,
+			Some("key-id:gandalf0"),
+			&"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+			&paseto::tokens::TimeBackend::Time,
+		)
+		.expect("Failed to validate token!");
+		println!("{:?}", verified_token);
+	}
 
-  {
-    println!("Using Chrono Crate");
-    let current_date_time = Utc::now();
-    let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+	{
+		println!("Using Chrono Crate");
+		let current_date_time = Utc::now();
+		let dt = Utc
+			.ymd(current_date_time.year() + 1, 7, 8)
+			.and_hms(9, 10, 11);
 
-    let token = paseto::tokens::PasetoBuilder::new()
-      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-      .set_issued_at_chrono(None)
-      .set_expiration_chrono(&dt)
-      .set_issuer("instructure")
-      .set_audience("wizards")
-      .set_jti("gandalf0")
-      .set_not_before_chrono(&Utc::now())
-      .set_subject("gandalf")
-      .set_claim("go-to", json!("mordor"))
-      .set_footer("key-id:gandalf0")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
-    println!("{:?}", token);
+		let token = paseto::tokens::PasetoBuilder::new()
+			.set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+			.set_issued_at_chrono(None)
+			.set_expiration_chrono(&dt)
+			.set_issuer("instructure")
+			.set_audience("wizards")
+			.set_jti("gandalf0")
+			.set_not_before_chrono(&Utc::now())
+			.set_subject("gandalf")
+			.set_claim("go-to", json!("mordor"))
+			.set_footer("key-id:gandalf0")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
+		println!("{:?}", token);
 
-    let verified_token = paseto::tokens::validate_local_token(
-      &token,
-      Some("key-id:gandalf0"),
-      &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
-      &paseto::tokens::TimeBackend::Chrono,
-    )
-    .expect("Failed to validate token!");
-    println!("{:?}", verified_token);
-  }
+		let verified_token = paseto::tokens::validate_local_token(
+			&token,
+			Some("key-id:gandalf0"),
+			&"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+			&paseto::tokens::TimeBackend::Chrono,
+		)
+		.expect("Failed to validate token!");
+		println!("{:?}", verified_token);
+	}
 }

--- a/examples/public-using-builder.rs
+++ b/examples/public-using-builder.rs
@@ -1,176 +1,216 @@
 #[cfg(all(feature = "v2", feature = "easy_tokens_chrono"))]
 use chrono::prelude::*;
-#[cfg(all(feature = "v2", any(feature = "easy_tokens_chrono", feature = "easy_tokens_time")))]
+#[cfg(all(
+	feature = "v2",
+	any(feature = "easy_tokens_chrono", feature = "easy_tokens_time")
+))]
 use serde_json::json;
 #[cfg(all(feature = "v2", feature = "easy_tokens_time"))]
 use time::{Date, OffsetDateTime, Time};
-#[cfg(all(feature = "v2", any(feature = "easy_tokens_chrono", feature = "easy_tokens_time")))]
+#[cfg(all(
+	feature = "v2",
+	any(feature = "easy_tokens_chrono", feature = "easy_tokens_time")
+))]
 use {ring::rand::SystemRandom, ring::signature::Ed25519KeyPair};
 
 fn main() {
-  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  chrono_example();
-  #[cfg(all(feature = "v2", feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
-  time_example();
-  #[cfg(all(feature = "v2", feature = "easy_tokens_time", feature = "easy_tokens_chrono"))]
-  chrono_and_time_example();
+	#[cfg(all(
+		feature = "v2",
+		feature = "easy_tokens_chrono",
+		not(feature = "easy_tokens_time")
+	))]
+	chrono_example();
+	#[cfg(all(
+		feature = "v2",
+		feature = "easy_tokens_time",
+		not(feature = "easy_tokens_chrono")
+	))]
+	time_example();
+	#[cfg(all(
+		feature = "v2",
+		feature = "easy_tokens_time",
+		feature = "easy_tokens_chrono"
+	))]
+	chrono_and_time_example();
 }
 
-#[cfg(all(feature = "v2", feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
+#[cfg(all(
+	feature = "v2",
+	feature = "easy_tokens_chrono",
+	not(feature = "easy_tokens_time")
+))]
 fn chrono_example() {
-  let current_date_time = Utc::now();
-  let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+	let current_date_time = Utc::now();
+	let dt = Utc
+		.ymd(current_date_time.year() + 1, 7, 8)
+		.and_hms(9, 10, 11);
 
-  let sys_rand = SystemRandom::new();
-  let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
-  let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+	let sys_rand = SystemRandom::new();
+	let key_pkcs8 =
+		Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+	let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
-  let token = paseto::tokens::PasetoBuilder::new()
-    .set_ed25519_key(&as_key)
-    .set_issued_at(None)
-    .set_expiration(&dt)
-    .set_issuer("instructure")
-    .set_audience("wizards")
-    .set_jti("gandalf0")
-    .set_not_before(&Utc::now())
-    .set_subject("gandalf")
-    .set_claim("go-to", json!("mordor"))
-    .set_footer("key-id:gandalf0")
-    .build()
-    .expect("Failed to construct paseto token w/ builder!");
-  println!("{:?}", token);
+	let token = paseto::tokens::PasetoBuilder::new()
+		.set_ed25519_key(&as_key)
+		.set_issued_at(None)
+		.set_expiration(&dt)
+		.set_issuer("instructure")
+		.set_audience("wizards")
+		.set_jti("gandalf0")
+		.set_not_before(&Utc::now())
+		.set_subject("gandalf")
+		.set_claim("go-to", json!("mordor"))
+		.set_footer("key-id:gandalf0")
+		.build()
+		.expect("Failed to construct paseto token w/ builder!");
+	println!("{:?}", token);
 
-  let verified_token = paseto::tokens::validate_public_token(
-    &token,
-    Some("key-id:gandalf0"),
-    &paseto::tokens::PasetoPublicKey::ED25519KeyPair(&as_key),
-    &paseto::tokens::TimeBackend::Chrono,
-  )
-  .expect("Failed to validate token!");
+	let verified_token = paseto::tokens::validate_public_token(
+		&token,
+		Some("key-id:gandalf0"),
+		&paseto::tokens::PasetoPublicKey::ED25519KeyPair(&as_key),
+		&paseto::tokens::TimeBackend::Chrono,
+	)
+	.expect("Failed to validate token!");
 
-  println!("{:?}", verified_token);
+	println!("{:?}", verified_token);
 }
 
-#[cfg(all(feature = "v2", feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
+#[cfg(all(
+	feature = "v2",
+	feature = "easy_tokens_time",
+	not(feature = "easy_tokens_chrono")
+))]
 fn time_example() {
-  let current_date_time = OffsetDateTime::now_utc();
-  let dt = Date::from_calendar_date(
-    current_date_time.year() + 1,
-    current_date_time.month(),
-    current_date_time.day(),
-  )
-  .unwrap()
-  .with_time(Time::from_hms(09, 10, 11).expect("Failed to create time 09:10:11"))
-  .assume_utc();
+	let current_date_time = OffsetDateTime::now_utc();
+	let dt = Date::from_calendar_date(
+		current_date_time.year() + 1,
+		current_date_time.month(),
+		current_date_time.day(),
+	)
+	.unwrap()
+	.with_time(Time::from_hms(09, 10, 11).expect("Failed to create time 09:10:11"))
+	.assume_utc();
 
-  let sys_rand = SystemRandom::new();
-  let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
-  let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+	let sys_rand = SystemRandom::new();
+	let key_pkcs8 =
+		Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+	let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
-  let token = paseto::tokens::PasetoBuilder::new()
-    .set_ed25519_key(&as_key)
-    .set_issued_at(None)
-    .set_expiration(&dt)
-    .set_issuer("instructure")
-    .set_audience("wizards")
-    .set_jti("gandalf0")
-    .set_not_before(&OffsetDateTime::now_utc())
-    .set_subject("gandalf")
-    .set_claim("go-to", json!("mordor"))
-    .set_footer("key-id:gandalf0")
-    .build()
-    .expect("Failed to construct paseto token w/ builder!");
-  println!("{:?}", token);
+	let token = paseto::tokens::PasetoBuilder::new()
+		.set_ed25519_key(&as_key)
+		.set_issued_at(None)
+		.set_expiration(&dt)
+		.set_issuer("instructure")
+		.set_audience("wizards")
+		.set_jti("gandalf0")
+		.set_not_before(&OffsetDateTime::now_utc())
+		.set_subject("gandalf")
+		.set_claim("go-to", json!("mordor"))
+		.set_footer("key-id:gandalf0")
+		.build()
+		.expect("Failed to construct paseto token w/ builder!");
+	println!("{:?}", token);
 
-  let verified_token = paseto::tokens::validate_public_token(
-    &token,
-    Some("key-id:gandalf0"),
-    &paseto::tokens::PasetoPublicKey::ED25519KeyPair(&as_key),
-    &paseto::tokens::TimeBackend::Time,
-  )
-  .expect("Failed to validate token!");
+	let verified_token = paseto::tokens::validate_public_token(
+		&token,
+		Some("key-id:gandalf0"),
+		&paseto::tokens::PasetoPublicKey::ED25519KeyPair(&as_key),
+		&paseto::tokens::TimeBackend::Time,
+	)
+	.expect("Failed to validate token!");
 
-  println!("{:?}", verified_token);
+	println!("{:?}", verified_token);
 }
 
-#[cfg(all(feature = "v2", feature = "easy_tokens_time", feature = "easy_tokens_chrono"))]
+#[cfg(all(
+	feature = "v2",
+	feature = "easy_tokens_time",
+	feature = "easy_tokens_chrono"
+))]
 fn chrono_and_time_example() {
-  {
-    println!("Using Time Crate!");
+	{
+		println!("Using Time Crate!");
 
-    let current_date_time = OffsetDateTime::now_utc();
-    let dt = Date::from_calendar_date(
-      current_date_time.year() + 1,
-      current_date_time.month(),
-      current_date_time.day(),
-    )
-    .unwrap()
-    .with_time(Time::from_hms(09, 10, 11).expect("Failed to parse time 09:10:11"))
-    .assume_utc();
+		let current_date_time = OffsetDateTime::now_utc();
+		let dt = Date::from_calendar_date(
+			current_date_time.year() + 1,
+			current_date_time.month(),
+			current_date_time.day(),
+		)
+		.unwrap()
+		.with_time(Time::from_hms(09, 10, 11).expect("Failed to parse time 09:10:11"))
+		.assume_utc();
 
-    let sys_rand = SystemRandom::new();
-    let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
-    let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+		let sys_rand = SystemRandom::new();
+		let key_pkcs8 =
+			Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+		let as_key =
+			Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
-    let token = paseto::tokens::PasetoBuilder::new()
-      .set_ed25519_key(&as_key)
-      .set_issued_at_time(None)
-      .set_expiration_time(&dt)
-      .set_issuer("instructure")
-      .set_audience("wizards")
-      .set_jti("gandalf0")
-      .set_not_before_time(&OffsetDateTime::now_utc())
-      .set_subject("gandalf")
-      .set_claim("go-to", json!("mordor"))
-      .set_footer("key-id:gandalf0")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
-    println!("{:?}", token);
+		let token = paseto::tokens::PasetoBuilder::new()
+			.set_ed25519_key(&as_key)
+			.set_issued_at_time(None)
+			.set_expiration_time(&dt)
+			.set_issuer("instructure")
+			.set_audience("wizards")
+			.set_jti("gandalf0")
+			.set_not_before_time(&OffsetDateTime::now_utc())
+			.set_subject("gandalf")
+			.set_claim("go-to", json!("mordor"))
+			.set_footer("key-id:gandalf0")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
+		println!("{:?}", token);
 
-    let verified_token = paseto::tokens::validate_public_token(
-      &token,
-      Some("key-id:gandalf0"),
-      &paseto::tokens::PasetoPublicKey::ED25519KeyPair(&as_key),
-      &paseto::tokens::TimeBackend::Time,
-    )
-    .expect("Failed to validate token!");
+		let verified_token = paseto::tokens::validate_public_token(
+			&token,
+			Some("key-id:gandalf0"),
+			&paseto::tokens::PasetoPublicKey::ED25519KeyPair(&as_key),
+			&paseto::tokens::TimeBackend::Time,
+		)
+		.expect("Failed to validate token!");
 
-    println!("{:?}", verified_token);
-  }
+		println!("{:?}", verified_token);
+	}
 
-  {
-    println!("Using Chrono Crate!");
+	{
+		println!("Using Chrono Crate!");
 
-    let current_date_time = Utc::now();
-    let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+		let current_date_time = Utc::now();
+		let dt = Utc
+			.ymd(current_date_time.year() + 1, 7, 8)
+			.and_hms(9, 10, 11);
 
-    let sys_rand = SystemRandom::new();
-    let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
-    let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+		let sys_rand = SystemRandom::new();
+		let key_pkcs8 =
+			Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+		let as_key =
+			Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
-    let token = paseto::tokens::PasetoBuilder::new()
-      .set_ed25519_key(&as_key)
-      .set_issued_at_chrono(None)
-      .set_expiration_chrono(&dt)
-      .set_issuer("instructure")
-      .set_audience("wizards")
-      .set_jti("gandalf0")
-      .set_not_before_chrono(&Utc::now())
-      .set_subject("gandalf")
-      .set_claim("go-to", json!("mordor"))
-      .set_footer("key-id:gandalf0")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
-    println!("{:?}", token);
+		let token = paseto::tokens::PasetoBuilder::new()
+			.set_ed25519_key(&as_key)
+			.set_issued_at_chrono(None)
+			.set_expiration_chrono(&dt)
+			.set_issuer("instructure")
+			.set_audience("wizards")
+			.set_jti("gandalf0")
+			.set_not_before_chrono(&Utc::now())
+			.set_subject("gandalf")
+			.set_claim("go-to", json!("mordor"))
+			.set_footer("key-id:gandalf0")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
+		println!("{:?}", token);
 
-    let verified_token = paseto::tokens::validate_public_token(
-      &token,
-      Some("key-id:gandalf0"),
-      &paseto::tokens::PasetoPublicKey::ED25519KeyPair(&as_key),
-      &paseto::tokens::TimeBackend::Chrono,
-    )
-    .expect("Failed to validate token!");
+		let verified_token = paseto::tokens::validate_public_token(
+			&token,
+			Some("key-id:gandalf0"),
+			&paseto::tokens::PasetoPublicKey::ED25519KeyPair(&as_key),
+			&paseto::tokens::TimeBackend::Chrono,
+		)
+		.expect("Failed to validate token!");
 
-    println!("{:?}", verified_token);
-  }
+		println!("{:?}", verified_token);
+	}
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,4 @@
-tab_spaces = 2
-max_width = 120
+edition = "2018"
+hard_tabs = true
+max_width = 100
+newline_style = "Unix"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,45 +1,71 @@
-use failure_derive::*;
+use thiserror::Error;
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
+pub enum PasetoError {
+	#[cfg(any(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
+	#[error(transparent)]
+	JsonError(#[from] serde_json::Error),
+	#[error(transparent)]
+	GenericError(#[from] GenericError),
+	#[error(transparent)]
+	LibsodiumError(#[from] SodiumErrors),
+	#[cfg(feature = "v1")]
+	#[error(transparent)]
+	OpensslError(#[from] openssl::error::ErrorStack),
+	#[error(transparent)]
+	RsaError(#[from] RsaKeyErrors),
+}
+
+#[derive(Debug, Error)]
 pub enum SodiumErrors {
-  #[fail(display = "invalid key size, needed: {} got: {}", size_needed, size_provided)]
-  InvalidKeySize { size_provided: usize, size_needed: usize },
-  #[fail(display = "invalid nonce size, needed: {} got: {}", size_needed, size_provided)]
-  InvalidNonceSize { size_provided: usize, size_needed: usize },
-  #[fail(display = "Invalid key for libsodium!")]
-  InvalidKey {},
-  #[fail(display = "Function call to C Sodium Failed.")]
-  FunctionError {},
-  #[fail(display = "Invalid Output Size specified")]
-  InvalidOutputSize {},
+	#[error("invalid key size, needed: {} got: {}", size_needed, size_provided)]
+	InvalidKeySize {
+		size_provided: usize,
+		size_needed: usize,
+	},
+	#[error("invalid nonce size, needed: {} got: {}", size_needed, size_provided)]
+	InvalidNonceSize {
+		size_provided: usize,
+		size_needed: usize,
+	},
+	#[error("Invalid key for libsodium!")]
+	InvalidKey {},
+	#[error("Function call to C Sodium Failed.")]
+	FunctionError {},
+	#[error("Invalid Output Size specified")]
+	InvalidOutputSize {},
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum RsaKeyErrors {
-  #[fail(display = "Invalid RSA Key Provided")]
-  InvalidKey {},
-  #[fail(display = "Failed to generate signed RSA content")]
-  SignError {},
+	#[error("Invalid RSA Key Provided")]
+	InvalidKey {},
+	#[error("Failed to generate signed RSA content")]
+	SignError {},
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Error)]
 pub enum GenericError {
-  #[fail(display = "No key of the correct type was provided")]
-  NoKeyProvided {},
-  #[fail(display = "This token is invalid.")]
-  InvalidToken {},
-  #[fail(display = "The claim: {}, has an invalid date", claim_name)]
-  UnparseableTokenDate { claim_name: &'static str },
-  #[fail(display = "This token has not yet been issued, the issued at claim (IAT) is in the future.")]
-  InvalidIssuedAtToken {},
-  #[fail(display = "This token is not valid yet (NBF claim).")]
-  InvalidNotBeforeToken {},
-  #[fail(display = "This token is expired (EXP claim).")]
-  ExpiredToken {},
-  #[fail(display = "This token has an invalid footer.")]
-  InvalidFooter {},
-  #[fail(display = "Failed to generate enough random bytes.")]
-  RandomError {},
-  #[fail(display = "Failed to perform HKDF")]
-  BadHkdf {},
+	#[error("Failed to perform HKDF")]
+	BadHkdf {},
+	#[error(transparent)]
+	Base64Error(#[from] base64::DecodeError),
+	#[error("This token is expired (EXP claim).")]
+	ExpiredToken {},
+	#[error("This token has an invalid footer.")]
+	InvalidFooter {},
+	#[error("This token has not yet been issued, the issued at claim (IAT) is in the future.")]
+	InvalidIssuedAtToken {},
+	#[error("This token is not valid yet (NBF claim).")]
+	InvalidNotBeforeToken {},
+	#[error("This token is invalid.")]
+	InvalidToken {},
+	#[error("No key of the correct type was provided")]
+	NoKeyProvided {},
+	#[error("Failed to generate enough random bytes.")]
+	RandomError {},
+	#[error(transparent)]
+	Utf8Error(#[from] std::string::FromUtf8Error),
+	#[error("The claim: {}, has an invalid date", claim_name)]
+	UnparseableTokenDate { claim_name: &'static str },
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,8 @@
 #![recursion_limit = "128"]
+#![allow(
+	clippy::match_wildcard_for_single_variants,
+	clippy::module_name_repetitions
+)]
 
 pub mod errors;
 pub mod pae;

--- a/src/pae.rs
+++ b/src/pae.rs
@@ -4,58 +4,63 @@
 /// Encodes a u64-bit unsigned integer into a little-endian binary string.
 ///
 /// * `to_encode` - The u8 to encode.
+#[allow(clippy::cast_possible_truncation)]
 fn le64(mut to_encode: u64) -> Vec<u8> {
-  let mut the_vec = Vec::with_capacity(8);
+	let mut the_vec = Vec::with_capacity(8);
 
-  for _idx in 0..8 {
-    the_vec.push((to_encode & 255) as u8);
-    to_encode = to_encode >> 8;
-  }
+	for _idx in 0..8 {
+		the_vec.push((to_encode & 255) as u8);
+		to_encode >>= 8;
+	}
 
-  the_vec
+	the_vec
 }
 
 /// Performs Pre-Authentication Encoding (or PAE) as described in the
 /// Paseto Specification v2.
 ///
 /// * `pieces` - The Pieces to concatenate, and encode together.
+#[must_use]
 pub fn pae<'a>(pieces: &'a [&'a [u8]]) -> Vec<u8> {
-  let the_vec = le64(pieces.len() as u64);
+	let the_vec = le64(pieces.len() as u64);
 
-  pieces.into_iter().fold(the_vec, |mut acc, piece| {
-    acc.extend(le64(piece.len() as u64));
-    acc.extend(piece.into_iter());
-    acc
-  })
+	pieces.iter().fold(the_vec, |mut acc, piece| {
+		acc.extend(le64(piece.len() as u64));
+		acc.extend(piece.iter());
+		acc
+	})
 }
 
 #[cfg(test)]
 mod unit_tests {
-  use super::*;
-  use hex;
+	use super::*;
+	use hex;
 
-  #[test]
-  fn test_le64() {
-    assert_eq!(vec![0, 0, 0, 0, 0, 0, 0, 0], le64(0));
-    assert_eq!(vec![10, 0, 0, 0, 0, 0, 0, 0], le64(10));
-  }
+	#[test]
+	fn test_le64() {
+		assert_eq!(vec![0, 0, 0, 0, 0, 0, 0, 0], le64(0));
+		assert_eq!(vec![10, 0, 0, 0, 0, 0, 0, 0], le64(10));
+	}
 
-  #[test]
-  fn test_pae() {
-    // Constants taken from paseto source.
-    assert_eq!("0000000000000000", hex::encode(&pae(&[])));
-    assert_eq!("01000000000000000000000000000000", hex::encode(&pae(&[&[]])));
-    assert_eq!(
-      "020000000000000000000000000000000000000000000000",
-      hex::encode(&pae(&[&[], &[]]))
-    );
-    assert_eq!(
-      "0100000000000000070000000000000050617261676f6e",
-      hex::encode(&pae(&["Paragon".as_bytes()]))
-    );
-    assert_eq!(
-      "0200000000000000070000000000000050617261676f6e0a00000000000000496e6974696174697665",
-      hex::encode(&pae(&["Paragon".as_bytes(), "Initiative".as_bytes(),]))
-    );
-  }
+	#[test]
+	fn test_pae() {
+		// Constants taken from paseto source.
+		assert_eq!("0000000000000000", hex::encode(&pae(&[])));
+		assert_eq!(
+			"01000000000000000000000000000000",
+			hex::encode(&pae(&[&[]]))
+		);
+		assert_eq!(
+			"020000000000000000000000000000000000000000000000",
+			hex::encode(&pae(&[&[], &[]]))
+		);
+		assert_eq!(
+			"0100000000000000070000000000000050617261676f6e",
+			hex::encode(&pae(&["Paragon".as_bytes()]))
+		);
+		assert_eq!(
+			"0200000000000000070000000000000050617261676f6e0a00000000000000496e6974696174697665",
+			hex::encode(&pae(&["Paragon".as_bytes(), "Initiative".as_bytes(),]))
+		);
+	}
 }

--- a/src/tokens/builder.rs
+++ b/src/tokens/builder.rs
@@ -1,6 +1,6 @@
-use crate::errors::GenericError;
 #[cfg(feature = "v1")]
 use crate::errors::RsaKeyErrors;
+use crate::errors::{GenericError, PasetoError};
 
 #[cfg(all(not(feature = "v2"), feature = "v1"))]
 use crate::v1::local_paseto as V1Local;
@@ -11,7 +11,6 @@ use crate::v2::{local_paseto as V2Local, public_paseto as V2Public};
 
 #[cfg(feature = "easy_tokens_chrono")]
 use chrono::prelude::*;
-use failure::Error;
 #[cfg(feature = "v2")]
 use ring::signature::Ed25519KeyPair;
 #[cfg(feature = "v1")]
@@ -24,344 +23,376 @@ use std::collections::HashMap;
 
 /// A paseto builder.
 pub struct PasetoBuilder<'a> {
-  /// Set the footer to use for this token.
-  footer: Option<&'a str>,
-  /// The encryption key to use. If present WILL use LOCAL tokens (or shared key encryption).
-  encryption_key: Option<&'a [u8]>,
-  /// The RSA Key pairs in DER format, for V1 Public Tokens.
-  #[cfg(feature = "v1")]
-  rsa_key: Option<&'a [u8]>,
-  /// The ED25519 Key Pair, for V2 Public Tokens.
-  #[cfg(feature = "v2")]
-  ed_key: Option<&'a Ed25519KeyPair>,
-  /// Any extra claims you want to store in your json.
-  extra_claims: HashMap<&'a str, Value>,
+	/// Set the footer to use for this token.
+	footer: Option<&'a str>,
+	/// The encryption key to use. If present WILL use LOCAL tokens (or shared key encryption).
+	encryption_key: Option<&'a [u8]>,
+	/// The RSA Key pairs in DER format, for V1 Public Tokens.
+	#[cfg(feature = "v1")]
+	rsa_key: Option<&'a [u8]>,
+	/// The ED25519 Key Pair, for V2 Public Tokens.
+	#[cfg(feature = "v2")]
+	ed_key: Option<&'a Ed25519KeyPair>,
+	/// Any extra claims you want to store in your json.
+	extra_claims: HashMap<&'a str, Value>,
 }
 
 impl<'a> PasetoBuilder<'a> {
-  /// Creates a new Paseto builder.
-  pub fn new() -> PasetoBuilder<'a> {
-    PasetoBuilder {
-      footer: None,
-      encryption_key: None,
-      #[cfg(feature = "v1")]
-      rsa_key: None,
-      #[cfg(feature = "v2")]
-      ed_key: None,
-      extra_claims: HashMap::new(),
-    }
-  }
+	/// Creates a new Paseto builder.
+	#[must_use]
+	pub fn new() -> PasetoBuilder<'a> {
+		PasetoBuilder {
+			footer: None,
+			encryption_key: None,
+			#[cfg(feature = "v1")]
+			rsa_key: None,
+			#[cfg(feature = "v2")]
+			ed_key: None,
+			extra_claims: HashMap::new(),
+		}
+	}
 
-  /// Builds a token.
-  pub fn build(&self) -> Result<String, Error> {
-    let strd_msg = to_string(&self.extra_claims)?;
+	/// Builds a token.
+	///
+	/// # Errors
+	///
+	/// If we fail to encrypt, or sign your token, or generate a random nonce.
+	pub fn build(&self) -> Result<String, PasetoError> {
+		let strd_msg = to_string(&self.extra_claims)?;
 
-    #[cfg(feature = "v2")]
-    {
-      if let Some(mut enc_key) = self.encryption_key {
-        return V2Local(&strd_msg, self.footer.as_deref(), &mut enc_key);
-      }
-    }
+		#[cfg(feature = "v2")]
+		{
+			if let Some(enc_key) = self.encryption_key {
+				return V2Local(&strd_msg, self.footer.as_deref(), enc_key);
+			}
+		}
 
-    #[cfg(all(not(feature = "v2"), feature = "v1"))]
-    {
-      if let Some(mut enc_key) = self.encryption_key {
-        return V1Local(&strd_msg, self.footer.as_deref(), &mut enc_key);
-      }
-    }
+		#[cfg(all(not(feature = "v2"), feature = "v1"))]
+		{
+			if let Some(enc_key) = self.encryption_key {
+				return V1Local(&strd_msg, self.footer.as_deref(), enc_key);
+			}
+		}
 
-    #[cfg(feature = "v2")]
-    {
-      if let Some(ed_key_pair) = self.ed_key {
-        return V2Public(&strd_msg, self.footer.as_deref(), &ed_key_pair);
-      }
-    }
+		#[cfg(feature = "v2")]
+		{
+			if let Some(ed_key_pair) = self.ed_key {
+				return V2Public(&strd_msg, self.footer.as_deref(), ed_key_pair);
+			}
+		}
 
-    #[cfg(feature = "v1")]
-    {
-      if let Some(the_rsa_key) = self.rsa_key {
-        let key_pair = RsaKeyPair::from_der(&the_rsa_key);
-        if key_pair.is_err() {
-          return Err(RsaKeyErrors::InvalidKey {})?;
-        }
-        let mut key_pair = key_pair.unwrap();
-        return V1Public(&strd_msg, self.footer.as_deref(), &mut key_pair);
-      }
-    }
+		#[cfg(feature = "v1")]
+		{
+			if let Some(the_rsa_key) = self.rsa_key {
+				return match RsaKeyPair::from_der(the_rsa_key) {
+					Ok(key_pair) => V1Public(&strd_msg, self.footer.as_deref(), &key_pair),
+					Err(_) => Err(RsaKeyErrors::InvalidKey {}.into()),
+				};
+			}
+		}
 
-    return Err(GenericError::NoKeyProvided {})?;
-  }
+		Err(GenericError::NoKeyProvided {}.into())
+	}
+}
+
+impl<'a> Default for PasetoBuilder<'a> {
+	fn default() -> Self {
+		Self::new()
+	}
 }
 
 #[cfg(feature = "v1")]
 impl<'a> PasetoBuilder<'a> {
-  /// Sets the RSA Key on a Paseto builder.
-  ///
-  /// NOTE: This will not be used if you set a symmetric encryption key, or if you specify an Ed25519 key pair.
-  pub fn set_rsa_key(&'a mut self, private_key_der: &'a [u8]) -> &'a mut Self {
-    self.rsa_key = Some(private_key_der);
-    self
-  }
+	/// Sets the RSA Key on a Paseto builder.
+	///
+	/// NOTE: This will not be used if you set a symmetric encryption key, or if you specify an Ed25519 key pair.
+	pub fn set_rsa_key(&'a mut self, private_key_der: &'a [u8]) -> &'a mut Self {
+		self.rsa_key = Some(private_key_der);
+		self
+	}
 }
 
 #[cfg(feature = "v2")]
 impl<'a> PasetoBuilder<'a> {
-  /// Sets the ED25519 Key pair.
-  ///
-  /// NOTE: This will not be used if you set a symmetric encryption key.
-  pub fn set_ed25519_key(&'a mut self, key_pair: &'a Ed25519KeyPair) -> &'a mut Self {
-    self.ed_key = Some(key_pair);
-    self
-  }
+	/// Sets the ED25519 Key pair.
+	///
+	/// NOTE: This will not be used if you set a symmetric encryption key.
+	pub fn set_ed25519_key(&'a mut self, key_pair: &'a Ed25519KeyPair) -> &'a mut Self {
+		self.ed_key = Some(key_pair);
+		self
+	}
 }
 
 impl<'a> PasetoBuilder<'a> {
-  /// Sets the encryption key to use for the paseto token.
-  ///
-  /// Keys should be exactly 32 bytes long, this is a requirement of the
-  /// underlying encryption algorithims.
-  ///
-  /// NOTE: If you set this we _*will*_ use a local token.
-  pub fn set_encryption_key(&'a mut self, encryption_key: &'a [u8]) -> &'a mut Self {
-    self.encryption_key = Some(encryption_key);
-    self
-  }
+	/// Sets the encryption key to use for the paseto token.
+	///
+	/// Keys should be exactly 32 bytes long, this is a requirement of the
+	/// underlying encryption algorithims.
+	///
+	/// NOTE: If you set this we _*will*_ use a local token.
+	pub fn set_encryption_key(&'a mut self, encryption_key: &'a [u8]) -> &'a mut Self {
+		self.encryption_key = Some(encryption_key);
+		self
+	}
 
-  //// Sets the footer to use for this token.
-  pub fn set_footer(&'a mut self, footer: &'a str) -> &'a mut Self {
-    self.footer = Some(footer);
-    self
-  }
+	//// Sets the footer to use for this token.
+	pub fn set_footer(&'a mut self, footer: &'a str) -> &'a mut Self {
+		self.footer = Some(footer);
+		self
+	}
 
-  /// Provide multiple arbitrary claims at once, if a key is already present it will be updated.
-  ///
-  /// Mirrors [`std::iter::Extend`] for normal maps.
-  pub fn extend_claims(&'a mut self, claims: HashMap<&'a str, Value>) -> &'a mut Self {
-    self.extra_claims.extend(claims);
-    self
-  }
+	/// Provide multiple arbitrary claims at once, if a key is already present it will be updated.
+	///
+	/// Mirrors [`std::iter::Extend`] for normal maps.
+	pub fn extend_claims(&'a mut self, claims: HashMap<&'a str, Value>) -> &'a mut Self {
+		self.extra_claims.extend(claims);
+		self
+	}
 
-  /// Sets an arbitrary claim (a key inside the json token).
-  pub fn set_claim(&'a mut self, key: &'a str, value: Value) -> &'a mut Self {
-    self.extra_claims.insert(key, value);
-    self
-  }
+	/// Sets an arbitrary claim (a key inside the json token).
+	pub fn set_claim(&'a mut self, key: &'a str, value: Value) -> &'a mut Self {
+		self.extra_claims.insert(key, value);
+		self
+	}
 
-  /// Sets the audience for this token.
-  pub fn set_audience(&'a mut self, audience: &str) -> &'a mut Self {
-    self.set_claim("aud", json!(audience))
-  }
+	/// Sets the audience for this token.
+	pub fn set_audience(&'a mut self, audience: &str) -> &'a mut Self {
+		self.set_claim("aud", json!(audience))
+	}
 
-  /// Sets the expiration date for this token.
-  #[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  pub fn set_expiration(&'a mut self, expiration: &DateTime<Utc>) -> &'a mut Self {
-    self.set_claim("exp", json!(expiration))
-  }
+	/// Sets the expiration date for this token.
+	#[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
+	pub fn set_expiration(&'a mut self, expiration: &DateTime<Utc>) -> &'a mut Self {
+		self.set_claim("exp", json!(expiration))
+	}
 
-  /// Sets the expiration date for this token.
-  #[cfg(all(feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
-  pub fn set_expiration(&'a mut self, expiration: &OffsetDateTime) -> &'a mut Self {
-    self.set_claim("exp", json!(expiration))
-  }
+	/// Sets the expiration date for this token.
+	#[cfg(all(feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
+	pub fn set_expiration(&'a mut self, expiration: &OffsetDateTime) -> &'a mut Self {
+		self.set_claim("exp", json!(expiration))
+	}
 
-  /// Sets the expiration date for this token.
-  #[cfg(all(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
-  pub fn set_expiration_chrono(&'a mut self, expiration: &DateTime<Utc>) -> &'a mut Self {
-    self.set_claim("exp", json!(expiration))
-  }
+	/// Sets the expiration date for this token.
+	#[cfg(all(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
+	pub fn set_expiration_chrono(&'a mut self, expiration: &DateTime<Utc>) -> &'a mut Self {
+		self.set_claim("exp", json!(expiration))
+	}
 
-  /// Sets the expiration date for this token.
-  #[cfg(all(feature = "easy_tokens_time", feature = "easy_tokens_time"))]
-  pub fn set_expiration_time(&'a mut self, expiration: &OffsetDateTime) -> &'a mut Self {
-    self.set_claim("exp", json!(expiration))
-  }
+	/// Sets the expiration date for this token.
+	#[cfg(all(feature = "easy_tokens_time", feature = "easy_tokens_time"))]
+	pub fn set_expiration_time(&'a mut self, expiration: &OffsetDateTime) -> &'a mut Self {
+		self.set_claim("exp", json!(expiration))
+	}
 
-  /// Sets the time this token was issued at.
-  ///
-  /// issued_at defaults to: Utc::now();
-  #[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  pub fn set_issued_at(&'a mut self, issued_at: Option<DateTime<Utc>>) -> &'a mut Self {
-    self.set_claim("iat", json!(issued_at.unwrap_or(Utc::now())))
-  }
+	/// Sets the time this token was issued at.
+	///
+	/// `issued_at` defaults to: `Utc::now()`
+	#[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
+	pub fn set_issued_at(&'a mut self, issued_at: Option<DateTime<Utc>>) -> &'a mut Self {
+		self.set_claim("iat", json!(issued_at.unwrap_or_else(Utc::now)))
+	}
 
-  /// Sets the time this token was issued at.
-  ///
-  /// issued_at defaults to: OffsetDateTime::now_utc();
-  #[cfg(all(feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
-  pub fn set_issued_at(&'a mut self, issued_at: Option<OffsetDateTime>) -> &'a mut Self {
-    self.set_claim("iat", json!(issued_at.unwrap_or(OffsetDateTime::now_utc())))
-  }
+	/// Sets the time this token was issued at.
+	///
+	/// `issued_at` defaults to: `OffsetDateTime::now_utc()`
+	#[cfg(all(feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
+	pub fn set_issued_at(&'a mut self, issued_at: Option<OffsetDateTime>) -> &'a mut Self {
+		self.set_claim(
+			"iat",
+			json!(issued_at.unwrap_or_else(OffsetDateTime::now_utc)),
+		)
+	}
 
-  /// Sets the time this token was issued at.
-  ///
-  /// issued_at defaults to: Utc::now();
-  #[cfg(all(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
-  pub fn set_issued_at_chrono(&'a mut self, issued_at: Option<DateTime<Utc>>) -> &'a mut Self {
-    self.set_claim("iat", json!(issued_at.unwrap_or(Utc::now())))
-  }
+	/// Sets the time this token was issued at.
+	///
+	/// `issued_at` defaults to: `Utc::now()`
+	#[cfg(all(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
+	pub fn set_issued_at_chrono(&'a mut self, issued_at: Option<DateTime<Utc>>) -> &'a mut Self {
+		self.set_claim("iat", json!(issued_at.unwrap_or_else(Utc::now)))
+	}
 
-  /// Sets the time this token was issued at.
-  ///
-  /// issued_at defaults to: OffsetDateTime::now_utc();
-  #[cfg(all(feature = "easy_tokens_time", feature = "easy_tokens_time"))]
-  pub fn set_issued_at_time(&'a mut self, issued_at: Option<OffsetDateTime>) -> &'a mut Self {
-    self.set_claim("iat", json!(issued_at.unwrap_or(OffsetDateTime::now_utc())))
-  }
+	/// Sets the time this token was issued at.
+	///
+	/// `issued_at` defaults to: `OffsetDateTime::now_utc()`
+	#[cfg(all(feature = "easy_tokens_time", feature = "easy_tokens_time"))]
+	pub fn set_issued_at_time(&'a mut self, issued_at: Option<OffsetDateTime>) -> &'a mut Self {
+		self.set_claim(
+			"iat",
+			json!(issued_at.unwrap_or_else(OffsetDateTime::now_utc)),
+		)
+	}
 
-  /// Sets the issuer for this token.
-  pub fn set_issuer(&'a mut self, issuer: &str) -> &'a mut Self {
-    self.set_claim("iss", json!(issuer))
-  }
+	/// Sets the issuer for this token.
+	pub fn set_issuer(&'a mut self, issuer: &str) -> &'a mut Self {
+		self.set_claim("iss", json!(issuer))
+	}
 
-  /// Sets the JTI ID for this token.
-  pub fn set_jti(&'a mut self, id: &str) -> &'a mut Self {
-    self.set_claim("jti", json!(id))
-  }
+	/// Sets the JTI ID for this token.
+	pub fn set_jti(&'a mut self, id: &str) -> &'a mut Self {
+		self.set_claim("jti", json!(id))
+	}
 
-  /// Sets the not before time.
-  #[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  pub fn set_not_before(&'a mut self, not_before: &DateTime<Utc>) -> &'a mut Self {
-    self.set_claim("nbf", json!(not_before))
-  }
+	/// Sets the not before time.
+	#[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
+	pub fn set_not_before(&'a mut self, not_before: &DateTime<Utc>) -> &'a mut Self {
+		self.set_claim("nbf", json!(not_before))
+	}
 
-  /// Sets the not before time.
-  #[cfg(all(feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
-  pub fn set_not_before(&'a mut self, not_before: &OffsetDateTime) -> &'a mut Self {
-    self.set_claim("nbf", json!(not_before))
-  }
+	/// Sets the not before time.
+	#[cfg(all(feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
+	pub fn set_not_before(&'a mut self, not_before: &OffsetDateTime) -> &'a mut Self {
+		self.set_claim("nbf", json!(not_before))
+	}
 
-  /// Sets the not before time.
-  #[cfg(all(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
-  pub fn set_not_before_chrono(&'a mut self, not_before: &DateTime<Utc>) -> &'a mut Self {
-    self.set_claim("nbf", json!(not_before))
-  }
+	/// Sets the not before time.
+	#[cfg(all(feature = "easy_tokens_chrono", feature = "easy_tokens_time"))]
+	pub fn set_not_before_chrono(&'a mut self, not_before: &DateTime<Utc>) -> &'a mut Self {
+		self.set_claim("nbf", json!(not_before))
+	}
 
-  /// Sets the not before time.
-  #[cfg(all(feature = "easy_tokens_time", feature = "easy_tokens_time"))]
-  pub fn set_not_before_time(&'a mut self, not_before: &OffsetDateTime) -> &'a mut Self {
-    self.set_claim("nbf", json!(not_before))
-  }
+	/// Sets the not before time.
+	#[cfg(all(feature = "easy_tokens_time", feature = "easy_tokens_time"))]
+	pub fn set_not_before_time(&'a mut self, not_before: &OffsetDateTime) -> &'a mut Self {
+		self.set_claim("nbf", json!(not_before))
+	}
 
-  /// Sets the subject for this token.
-  pub fn set_subject(&'a mut self, subject: &str) -> &'a mut Self {
-    self.set_claim("sub", json!(subject))
-  }
+	/// Sets the subject for this token.
+	pub fn set_subject(&'a mut self, subject: &str) -> &'a mut Self {
+		self.set_claim("sub", json!(subject))
+	}
 }
 
 #[cfg(test)]
 mod unit_test {
-  #[cfg(feature = "v2")]
-  use {super::*, crate::v2::local::decrypt_paseto as V2Decrypt, serde_json::from_str as ParseJson};
+	#[cfg(feature = "v2")]
+	use {
+		super::*, crate::v2::local::decrypt_paseto as V2Decrypt, serde_json::from_str as ParseJson,
+	};
 
-  #[test]
-  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  fn can_construct_a_token_chrono_with_extend_claims() {
-    //set or get a map of any number of claims
-    let mut arbitrary_claims = HashMap::new();
-    arbitrary_claims.insert("claim1", json!("data1"));
-    arbitrary_claims.insert("claim2", json!("data2"));
-    arbitrary_claims.insert("claim3", json!("data3"));
-    arbitrary_claims.insert("claim4", json!("data4"));
-    arbitrary_claims.insert("claim5", json!("data5"));
+	#[test]
+	#[cfg(all(
+		feature = "v2",
+		feature = "easy_tokens_chrono",
+		not(feature = "easy_tokens_time")
+	))]
+	fn can_construct_a_token_chrono_with_extend_claims() {
+		//set or get a map of any number of claims
+		let mut arbitrary_claims = HashMap::new();
+		arbitrary_claims.insert("claim1", json!("data1"));
+		arbitrary_claims.insert("claim2", json!("data2"));
+		arbitrary_claims.insert("claim3", json!("data3"));
+		arbitrary_claims.insert("claim4", json!("data4"));
+		arbitrary_claims.insert("claim5", json!("data5"));
 
-    let token = PasetoBuilder::new()
-      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-      .set_issued_at(None)
-      .set_expiration(&Utc::now())
-      .set_issuer("issuer")
-      .set_audience("audience")
-      .set_jti("jti")
-      .set_not_before(&Utc::now())
-      .set_subject("test")
-      .extend_claims(arbitrary_claims)
-      .set_footer("footer")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
+		let token = PasetoBuilder::new()
+			.set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+			.set_issued_at(None)
+			.set_expiration(&Utc::now())
+			.set_issuer("issuer")
+			.set_audience("audience")
+			.set_jti("jti")
+			.set_not_before(&Utc::now())
+			.set_subject("test")
+			.extend_claims(arbitrary_claims)
+			.set_footer("footer")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
 
-    let decrypted_token = V2Decrypt(
-      &token,
-      Some("footer"),
-      &mut Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
-    )
-    .expect("Failed to decrypt token constructed with builder!");
+		let decrypted_token = V2Decrypt(
+			&token,
+			Some("footer"),
+			&mut Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
+		)
+		.expect("Failed to decrypt token constructed with builder!");
 
-    let parsed: Value = ParseJson(&decrypted_token).expect("Failed to parse finalized token as json!");
+		let parsed: Value =
+			ParseJson(&decrypted_token).expect("Failed to parse finalized token as json!");
 
-    assert!(parsed.get("claim1").is_some());
-    assert!(parsed.get("claim2").is_some());
-    assert!(parsed.get("claim3").is_some());
-    assert!(parsed.get("claim4").is_some());
-    assert!(parsed.get("claim5").is_some());
-    assert!(parsed.get("claim6").is_none());
-  }
+		assert!(parsed.get("claim1").is_some());
+		assert!(parsed.get("claim2").is_some());
+		assert!(parsed.get("claim3").is_some());
+		assert!(parsed.get("claim4").is_some());
+		assert!(parsed.get("claim5").is_some());
+		assert!(parsed.get("claim6").is_none());
+	}
 
-  #[test]
-  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  fn can_construct_a_token_chrono() {
-    let token = PasetoBuilder::new()
-      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-      .set_issued_at(None)
-      .set_expiration(&Utc::now())
-      .set_issuer("issuer")
-      .set_audience("audience")
-      .set_jti("jti")
-      .set_not_before(&Utc::now())
-      .set_subject("test")
-      .set_claim("claim", json!("data"))
-      .set_footer("footer")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
+	#[test]
+	#[cfg(all(
+		feature = "v2",
+		feature = "easy_tokens_chrono",
+		not(feature = "easy_tokens_time")
+	))]
+	fn can_construct_a_token_chrono() {
+		let token = PasetoBuilder::new()
+			.set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+			.set_issued_at(None)
+			.set_expiration(&Utc::now())
+			.set_issuer("issuer")
+			.set_audience("audience")
+			.set_jti("jti")
+			.set_not_before(&Utc::now())
+			.set_subject("test")
+			.set_claim("claim", json!("data"))
+			.set_footer("footer")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
 
-    let decrypted_token = V2Decrypt(
-      &token,
-      Some("footer"),
-      &mut Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
-    )
-    .expect("Failed to decrypt token constructed with builder!");
+		let decrypted_token = V2Decrypt(
+			&token,
+			Some("footer"),
+			&mut Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
+		)
+		.expect("Failed to decrypt token constructed with builder!");
 
-    let parsed: Value = ParseJson(&decrypted_token).expect("Failed to parse finalized token as json!");
+		let parsed: Value =
+			ParseJson(&decrypted_token).expect("Failed to parse finalized token as json!");
 
-    assert!(parsed.get("iat").is_some());
-    assert!(parsed.get("iss").is_some());
-    assert!(parsed.get("aud").is_some());
-    assert!(parsed.get("jti").is_some());
-    assert!(parsed.get("sub").is_some());
-    assert!(parsed.get("claim").is_some());
-    assert!(parsed.get("nbf").is_some());
-  }
+		assert!(parsed.get("iat").is_some());
+		assert!(parsed.get("iss").is_some());
+		assert!(parsed.get("aud").is_some());
+		assert!(parsed.get("jti").is_some());
+		assert!(parsed.get("sub").is_some());
+		assert!(parsed.get("claim").is_some());
+		assert!(parsed.get("nbf").is_some());
+	}
 
-  #[test]
-  #[cfg(all(feature = "v2", feature = "easy_tokens_time", not(feature = "easy_tokens_chrono")))]
-  fn can_construct_a_token_time() {
-    let token = PasetoBuilder::new()
-      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-      .set_issued_at(None)
-      .set_expiration(&OffsetDateTime::now_utc())
-      .set_issuer("issuer")
-      .set_audience("audience")
-      .set_jti("jti")
-      .set_not_before(&OffsetDateTime::now_utc())
-      .set_subject("test")
-      .set_claim("claim", json!("data"))
-      .set_footer("footer")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
+	#[test]
+	#[cfg(all(
+		feature = "v2",
+		feature = "easy_tokens_time",
+		not(feature = "easy_tokens_chrono")
+	))]
+	fn can_construct_a_token_time() {
+		let token = PasetoBuilder::new()
+			.set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+			.set_issued_at(None)
+			.set_expiration(&OffsetDateTime::now_utc())
+			.set_issuer("issuer")
+			.set_audience("audience")
+			.set_jti("jti")
+			.set_not_before(&OffsetDateTime::now_utc())
+			.set_subject("test")
+			.set_claim("claim", json!("data"))
+			.set_footer("footer")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
 
-    let decrypted_token = V2Decrypt(
-      &token,
-      Some("footer"),
-      &mut Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
-    )
-    .expect("Failed to decrypt token constructed with builder!");
+		let decrypted_token = V2Decrypt(
+			&token,
+			Some("footer"),
+			&mut Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()),
+		)
+		.expect("Failed to decrypt token constructed with builder!");
 
-    let parsed: Value = ParseJson(&decrypted_token).expect("Failed to parse finalized token as json!");
+		let parsed: Value =
+			ParseJson(&decrypted_token).expect("Failed to parse finalized token as json!");
 
-    assert!(parsed.get("iat").is_some());
-    assert!(parsed.get("iss").is_some());
-    assert!(parsed.get("aud").is_some());
-    assert!(parsed.get("jti").is_some());
-    assert!(parsed.get("sub").is_some());
-    assert!(parsed.get("claim").is_some());
-    assert!(parsed.get("nbf").is_some());
-  }
+		assert!(parsed.get("iat").is_some());
+		assert!(parsed.get("iss").is_some());
+		assert!(parsed.get("aud").is_some());
+		assert!(parsed.get("jti").is_some());
+		assert!(parsed.get("sub").is_some());
+		assert!(parsed.get("claim").is_some());
+		assert!(parsed.get("nbf").is_some());
+	}
 }

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -1,7 +1,7 @@
 //! Provides a "nice" wrapper around paseto tokens in order to check things such as "Expiration".
 //! Issuer, etc.
 
-use crate::errors::GenericError;
+use crate::errors::{GenericError, PasetoError};
 
 #[cfg(feature = "v1")]
 use crate::v1::{decrypt_paseto as V1Decrypt, verify_paseto as V1Verify};
@@ -10,7 +10,6 @@ use crate::v2::{decrypt_paseto as V2Decrypt, verify_paseto as V2Verify};
 
 #[cfg(feature = "easy_tokens_chrono")]
 use chrono::prelude::*;
-use failure::Error;
 #[cfg(feature = "v2")]
 use ring::signature::{Ed25519KeyPair, KeyPair};
 use serde_json::{from_str as ParseJson, Value as JsonValue};
@@ -23,488 +22,539 @@ pub use self::builder::*;
 /// Wraps the two paseto public key types so we can just have a `validate_public_token`
 /// method without splitting the two implementations.
 pub enum PasetoPublicKey<'a> {
-  #[cfg(feature = "v1")]
-  RSAPublicKey(&'a [u8]),
-  #[cfg(feature = "v2")]
-  ED25519KeyPair(&'a Ed25519KeyPair),
-  #[cfg(feature = "v2")]
-  ED25519PublicKey(&'a [u8]),
+	#[cfg(feature = "v1")]
+	RSAPublicKey(&'a [u8]),
+	#[cfg(feature = "v2")]
+	ED25519KeyPair(&'a Ed25519KeyPair),
+	#[cfg(feature = "v2")]
+	ED25519PublicKey(&'a [u8]),
 }
 
 /// Specifies which time crate will be used as backend for validating a token's
-/// datetimes, i.e. issued_at. The available backends are [`Chrono`] and [`Time`],
+/// datetimes, i.e. `issued_at`. The available backends are [`Chrono`] and [`Time`],
 /// the can be enabled via the features `easy_tokens_chrono` and `easy_tokens_time`.
 /// The default feature and backend is [`Chrono`].
 ///
 /// [`Chrono`]: https://docs.rs/chrono/*/chrono/index.html
 /// [`Time`]: https://docs.rs/time/*/time/index.html
 pub enum TimeBackend {
-  #[cfg(feature = "easy_tokens_chrono")]
-  Chrono,
-  #[cfg(feature = "easy_tokens_time")]
-  Time,
+	#[cfg(feature = "easy_tokens_chrono")]
+	Chrono,
+	#[cfg(feature = "easy_tokens_time")]
+	Time,
 }
 
-/// Validates a potential json data blob, returning a JsonValue.
+/// Validates a potential json data blob, returning a `JsonValue`.
 ///
 /// This specifically validates:
-///   * issued_at
-///   * expired
-///   * not_before
+///   * `issued_at`
+///   * `expired`
+///   * `not_before`
 ///
 /// This specifically does not validate:
-///   * audience
-///   * jti
-///   * issuedBy
-///   * subject
-pub fn validate_potential_json_blob(data: &str, backend: &TimeBackend) -> Result<JsonValue, Error> {
-  let value: JsonValue = ParseJson(data)?;
+///   * `audience`
+///   * `jti`
+///   * `issuedBy`
+///   * `subject`
+///
+/// # Errors
+///
+/// If the data of the token is not valid JSON, or contains invalid
+/// `issued_at`, `expired`, or `not_before` values.
+pub fn validate_potential_json_blob(
+	data: &str,
+	backend: &TimeBackend,
+) -> Result<JsonValue, PasetoError> {
+	let value: JsonValue = ParseJson(data)?;
 
-  match backend {
-    #[cfg(feature = "easy_tokens_chrono")]
-    TimeBackend::Chrono => {
-      let iat_value = value.get("iat");
-      if iat_value.is_some() {
-        let parsed_iat = iat_value
-          .and_then(|issued_at| issued_at.as_str())
-          .ok_or(GenericError::UnparseableTokenDate { claim_name: "iat" })
-          .and_then(|iat| {
-            iat
-              .parse::<DateTime<Utc>>()
-              .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "iat" })
-          })?;
+	match backend {
+		#[cfg(feature = "easy_tokens_chrono")]
+		TimeBackend::Chrono => {
+			let iat_value = value.get("iat");
+			if iat_value.is_some() {
+				let parsed_iat = iat_value
+					.and_then(serde_json::Value::as_str)
+					.ok_or(GenericError::UnparseableTokenDate { claim_name: "iat" })
+					.and_then(|iat| {
+						iat.parse::<DateTime<Utc>>()
+							.map_err(|_| GenericError::UnparseableTokenDate { claim_name: "iat" })
+					})?;
 
-        if parsed_iat > Utc::now() {
-          return Err(GenericError::InvalidIssuedAtToken {})?;
-        }
-      }
+				if parsed_iat > Utc::now() {
+					return Err(GenericError::InvalidIssuedAtToken {}.into());
+				}
+			}
 
-      let exp_value = value.get("exp");
-      if exp_value.is_some() {
-        let parsed_exp = exp_value
-          .and_then(|expired| expired.as_str())
-          .ok_or(GenericError::UnparseableTokenDate { claim_name: "exp" })
-          .and_then(|exp| {
-            exp
-              .parse::<DateTime<Utc>>()
-              .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "exp" })
-          })?;
+			let exp_value = value.get("exp");
+			if exp_value.is_some() {
+				let parsed_exp = exp_value
+					.and_then(serde_json::Value::as_str)
+					.ok_or(GenericError::UnparseableTokenDate { claim_name: "exp" })
+					.and_then(|exp| {
+						exp.parse::<DateTime<Utc>>()
+							.map_err(|_| GenericError::UnparseableTokenDate { claim_name: "exp" })
+					})?;
 
-        if parsed_exp < Utc::now() {
-          return Err(GenericError::ExpiredToken {})?;
-        }
-      }
+				if parsed_exp < Utc::now() {
+					return Err(GenericError::ExpiredToken {}.into());
+				}
+			}
 
-      let nbf_value = value.get("nbf");
-      if nbf_value.is_some() {
-        let parsed_nbf = nbf_value
-          .and_then(|not_before| not_before.as_str())
-          .ok_or(GenericError::UnparseableTokenDate { claim_name: "nbf" })
-          .and_then(|nbf| {
-            nbf
-              .parse::<DateTime<Utc>>()
-              .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "nbf" })
-          })?;
+			let nbf_value = value.get("nbf");
+			if nbf_value.is_some() {
+				let parsed_nbf = nbf_value
+					.and_then(serde_json::Value::as_str)
+					.ok_or(GenericError::UnparseableTokenDate { claim_name: "nbf" })
+					.and_then(|nbf| {
+						nbf.parse::<DateTime<Utc>>()
+							.map_err(|_| GenericError::UnparseableTokenDate { claim_name: "nbf" })
+					})?;
 
-        if parsed_nbf > Utc::now() {
-          return Err(GenericError::InvalidNotBeforeToken {})?;
-        }
-      }
+				if parsed_nbf > Utc::now() {
+					return Err(GenericError::InvalidNotBeforeToken {}.into());
+				}
+			}
 
-      Ok(value)
-    }
-    #[cfg(feature = "easy_tokens_time")]
-    TimeBackend::Time => {
-      let iat_value = value.get("iat");
-      if iat_value.is_some() {
-        let parsed_iat = iat_value
-          .and_then(|issued_at| issued_at.as_str())
-          .ok_or(GenericError::UnparseableTokenDate { claim_name: "iat" })
-          .and_then(|iat| {
-            OffsetDateTime::parse(iat, &time::format_description::well_known::Rfc3339)
-              .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "iat" })
-          })?;
+			Ok(value)
+		}
+		#[cfg(feature = "easy_tokens_time")]
+		TimeBackend::Time => {
+			let iat_value = value.get("iat");
+			if iat_value.is_some() {
+				let parsed_iat = iat_value
+					.and_then(serde_json::Value::as_str)
+					.ok_or(GenericError::UnparseableTokenDate { claim_name: "iat" })
+					.and_then(|iat| {
+						OffsetDateTime::parse(iat, &time::format_description::well_known::Rfc3339)
+							.map_err(|_| GenericError::UnparseableTokenDate { claim_name: "iat" })
+					})?;
 
-        if parsed_iat > OffsetDateTime::now_utc() {
-          return Err(GenericError::InvalidIssuedAtToken {})?;
-        }
-      }
+				if parsed_iat > OffsetDateTime::now_utc() {
+					return Err(GenericError::InvalidIssuedAtToken {}.into());
+				}
+			}
 
-      let exp_value = value.get("exp");
-      if exp_value.is_some() {
-        let parsed_exp = exp_value
-          .and_then(|expired| expired.as_str())
-          .ok_or(GenericError::UnparseableTokenDate { claim_name: "exp" })
-          .and_then(|exp| {
-            OffsetDateTime::parse(exp, &time::format_description::well_known::Rfc3339)
-              .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "exp" })
-          })?;
+			let exp_value = value.get("exp");
+			if exp_value.is_some() {
+				let parsed_exp = exp_value
+					.and_then(serde_json::Value::as_str)
+					.ok_or(GenericError::UnparseableTokenDate { claim_name: "exp" })
+					.and_then(|exp| {
+						OffsetDateTime::parse(exp, &time::format_description::well_known::Rfc3339)
+							.map_err(|_| GenericError::UnparseableTokenDate { claim_name: "exp" })
+					})?;
 
-        if parsed_exp < OffsetDateTime::now_utc() {
-          return Err(GenericError::ExpiredToken {})?;
-        }
-      }
+				if parsed_exp < OffsetDateTime::now_utc() {
+					return Err(GenericError::ExpiredToken {}.into());
+				}
+			}
 
-      let nbf_value = value.get("nbf");
-      if nbf_value.is_some() {
-        let parsed_nbf = nbf_value
-          .and_then(|not_before| not_before.as_str())
-          .ok_or(GenericError::UnparseableTokenDate { claim_name: "nbf" })
-          .and_then(|nbf| {
-            OffsetDateTime::parse(nbf, &time::format_description::well_known::Rfc3339)
-              .map_err(|_| GenericError::UnparseableTokenDate { claim_name: "nbf" })
-          })?;
+			let nbf_value = value.get("nbf");
+			if nbf_value.is_some() {
+				let parsed_nbf = nbf_value
+					.and_then(serde_json::Value::as_str)
+					.ok_or(GenericError::UnparseableTokenDate { claim_name: "nbf" })
+					.and_then(|nbf| {
+						OffsetDateTime::parse(nbf, &time::format_description::well_known::Rfc3339)
+							.map_err(|_| GenericError::UnparseableTokenDate { claim_name: "nbf" })
+					})?;
 
-        if parsed_nbf > OffsetDateTime::now_utc() {
-          return Err(GenericError::InvalidNotBeforeToken {})?;
-        }
-      }
+				if parsed_nbf > OffsetDateTime::now_utc() {
+					return Err(GenericError::InvalidNotBeforeToken {}.into());
+				}
+			}
 
-      Ok(value)
-    }
-  }
+			Ok(value)
+		}
+	}
 }
 
 /// Validate a local token for V1, or V2.
 ///
 /// This specifically validates:
-///   * issued_at
-///   * expired
-///   * not_before
+///   * `issued_at`
+///   * `expired`
+///   * `not_before`
 ///
 /// This specifically does not validate:
-///   * audience
-///   * jti
-///   * issuedBy
-///   * subject
+///   * `audience`
+///   * `jti`
+///   * `issuedBy`
+///   * `subject`
 ///
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
+///
+/// # Errors
+///
+/// 1. If we fail to decrypt the local token.
+/// 2. If any of the token fields are invalid: `issued_at`, `expired`, or `not_before`.
 pub fn validate_local_token(
-  token: &str,
-  footer: Option<&str>,
-  key: &[u8],
-  backend: &TimeBackend,
-) -> Result<JsonValue, Error> {
-  #[cfg(feature = "v2")]
-  {
-    if token.starts_with("v2.local.") {
-      let message = V2Decrypt(token, footer, &key)?;
-      return validate_potential_json_blob(&message, backend);
-    }
-  }
+	token: &str,
+	footer: Option<&str>,
+	key: &[u8],
+	backend: &TimeBackend,
+) -> Result<JsonValue, PasetoError> {
+	#[cfg(feature = "v2")]
+	{
+		if token.starts_with("v2.local.") {
+			let message = V2Decrypt(token, footer, key)?;
+			return validate_potential_json_blob(&message, backend);
+		}
+	}
 
-  #[cfg(feature = "v1")]
-  {
-    if token.starts_with("v1.local.") {
-      let message = V1Decrypt(token, footer, &key)?;
-      return validate_potential_json_blob(&message, backend);
-    }
-  }
+	#[cfg(feature = "v1")]
+	{
+		if token.starts_with("v1.local.") {
+			let message = V1Decrypt(token, footer, key)?;
+			return validate_potential_json_blob(&message, backend);
+		}
+	}
 
-  return Err(GenericError::InvalidToken {})?;
+	Err(GenericError::InvalidToken {}.into())
 }
 
 /// Validate a public token for V1, or V2.
 ///
 /// This specifically validates:
-///   * issued_at
-///   * expired
-///   * not_before
+///   * `issued_at`
+///   * `expired`
+///   * `not_before`
 ///
 /// This specifically does not validate:
-///   * audience
-///   * jti
-///   * issuedBy
-///   * subject
+///   * `audience`
+///   * `jti`
+///   * `issuedBy`
+///   * `subject`
 ///
 /// Because we validate these fields the resulting type must be a json object. If it's not
 /// please use the protocol impls directly.
+///
+/// # Errors
+///
+/// 1. If the token cannot be decrypted.
+/// 2. If any of the claims are not valid `issued_at`, `expired`, `not_before`.
 pub fn validate_public_token(
-  token: &str,
-  footer: Option<&str>,
-  key: &PasetoPublicKey,
-  backend: &TimeBackend,
-) -> Result<JsonValue, Error> {
-  #[cfg(feature = "v2")]
-  {
-    if token.starts_with("v2.public.") {
-      return match key {
-        PasetoPublicKey::ED25519KeyPair(key_pair) => {
-          let internal_msg = V2Verify(token, footer, key_pair.public_key().as_ref())?;
-          validate_potential_json_blob(&internal_msg, backend)
-        }
-        PasetoPublicKey::ED25519PublicKey(pub_key_contents) => {
-          let internal_msg = V2Verify(token, footer, &pub_key_contents)?;
-          validate_potential_json_blob(&internal_msg, backend)
-        }
-        #[cfg(feature = "v1")]
-        _ => Err(GenericError::NoKeyProvided {})?,
-      };
-    }
-  }
+	token: &str,
+	footer: Option<&str>,
+	key: &PasetoPublicKey,
+	backend: &TimeBackend,
+) -> Result<JsonValue, PasetoError> {
+	#[cfg(feature = "v2")]
+	{
+		if token.starts_with("v2.public.") {
+			return match key {
+				PasetoPublicKey::ED25519KeyPair(key_pair) => {
+					let internal_msg = V2Verify(token, footer, key_pair.public_key().as_ref())?;
+					validate_potential_json_blob(&internal_msg, backend)
+				}
+				PasetoPublicKey::ED25519PublicKey(pub_key_contents) => {
+					let internal_msg = V2Verify(token, footer, pub_key_contents)?;
+					validate_potential_json_blob(&internal_msg, backend)
+				}
+				#[cfg(feature = "v1")]
+				_ => Err(GenericError::NoKeyProvided {}.into()),
+			};
+		}
+	}
 
-  #[cfg(feature = "v1")]
-  {
-    if token.starts_with("v1.public.") {
-      return match key {
-        PasetoPublicKey::RSAPublicKey(key_content) => {
-          let internal_msg = V1Verify(token, footer, &key_content)?;
-          validate_potential_json_blob(&internal_msg, backend)
-        }
-        #[cfg(feature = "v2")]
-        _ => Err(GenericError::NoKeyProvided {})?,
-      };
-    }
-  }
+	#[cfg(feature = "v1")]
+	{
+		if token.starts_with("v1.public.") {
+			return match key {
+				PasetoPublicKey::RSAPublicKey(key_content) => {
+					let internal_msg = V1Verify(token, footer, key_content)?;
+					validate_potential_json_blob(&internal_msg, backend)
+				}
+				#[cfg(feature = "v2")]
+				_ => Err(GenericError::NoKeyProvided {}.into()),
+			};
+		}
+	}
 
-  return Err(GenericError::InvalidToken {})?;
+	Err(GenericError::InvalidToken {}.into())
 }
 
 #[cfg(test)]
 mod unit_tests {
-  use super::*;
-  #[cfg(feature = "easy_tokens_chrono")]
-  use chrono::Duration;
-  #[cfg(feature = "v2")]
-  use ring::rand::SystemRandom;
-  use serde_json::json;
+	use super::*;
+	#[cfg(feature = "easy_tokens_chrono")]
+	use chrono::Duration;
+	#[cfg(feature = "v2")]
+	use ring::rand::SystemRandom;
+	use serde_json::json;
 
-  #[test]
-  #[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  fn valid_enc_token_passes_test() {
-    let current_date_time = Utc::now();
-    let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+	#[test]
+	#[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
+	fn valid_enc_token_passes_test() {
+		let current_date_time = Utc::now();
+		let dt = Utc
+			.ymd(current_date_time.year() + 1, 7, 8)
+			.and_hms(9, 10, 11);
 
-    let token = PasetoBuilder::new()
-      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-      .set_issued_at(None)
-      .set_expiration(&dt)
-      .set_issuer("issuer")
-      .set_audience("audience")
-      .set_jti("jti")
-      .set_not_before(&Utc::now())
-      .set_subject("test")
-      .set_claim("claim", json!("data"))
-      .set_footer("footer")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
+		let token = PasetoBuilder::new()
+			.set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+			.set_issued_at(None)
+			.set_expiration(&dt)
+			.set_issuer("issuer")
+			.set_audience("audience")
+			.set_jti("jti")
+			.set_not_before(&Utc::now())
+			.set_subject("test")
+			.set_claim("claim", json!("data"))
+			.set_footer("footer")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
 
-    validate_local_token(
-      &token,
-      Some("footer"),
-      &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
-      &TimeBackend::Chrono,
-    )
-    .expect("Failed to validate token!");
-  }
+		validate_local_token(
+			&token,
+			Some("footer"),
+			&"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+			&TimeBackend::Chrono,
+		)
+		.expect("Failed to validate token!");
+	}
 
-  #[test]
-  #[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  fn valid_enc_token_expired_test() {
-    let current_date_time = Utc::now();
-    let dt = Utc.ymd(current_date_time.year() - 1, 7, 8).and_hms(9, 10, 11);
+	#[test]
+	#[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
+	fn valid_enc_token_expired_test() {
+		let current_date_time = Utc::now();
+		let dt = Utc
+			.ymd(current_date_time.year() - 1, 7, 8)
+			.and_hms(9, 10, 11);
 
-    let token = PasetoBuilder::new()
-      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-      .set_issued_at(None)
-      .set_expiration(&dt)
-      .set_issuer("issuer")
-      .set_audience("audience")
-      .set_jti("jti")
-      .set_not_before(&Utc::now())
-      .set_subject("test")
-      .set_claim("claim", json!("data"))
-      .set_footer("footer")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
+		let token = PasetoBuilder::new()
+			.set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+			.set_issued_at(None)
+			.set_expiration(&dt)
+			.set_issuer("issuer")
+			.set_audience("audience")
+			.set_jti("jti")
+			.set_not_before(&Utc::now())
+			.set_subject("test")
+			.set_claim("claim", json!("data"))
+			.set_footer("footer")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
 
-    let _error: failure::Error = (GenericError::ExpiredToken {}).into();
+		let _error: PasetoError = (GenericError::ExpiredToken {}).into();
 
-    assert!(matches!(
-      validate_local_token(
-        &token,
-        Some("footer"),
-        &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
-        &TimeBackend::Chrono
-      ),
-      Err(_error)
-    ));
-  }
+		assert!(matches!(
+			validate_local_token(
+				&token,
+				Some("footer"),
+				&"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+				&TimeBackend::Chrono
+			),
+			Err(_error)
+		));
+	}
 
-  #[test]
-  #[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  fn valid_enc_token_not_before_test() {
-    let current_date_time = Utc::now();
-    let dt = Utc.ymd(current_date_time.year() - 1, 7, 8).and_hms(9, 10, 11);
+	#[test]
+	#[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
+	fn valid_enc_token_not_before_test() {
+		let current_date_time = Utc::now();
+		let dt = Utc
+			.ymd(current_date_time.year() - 1, 7, 8)
+			.and_hms(9, 10, 11);
 
-    let token = PasetoBuilder::new()
-      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-      .set_issued_at(None)
-      .set_expiration(&dt)
-      .set_issuer("issuer")
-      .set_audience("audience")
-      .set_jti("jti")
-      .set_not_before(&(Utc::now() + Duration::days(1)))
-      .set_subject("test")
-      .set_claim("claim", json!("data"))
-      .set_footer("footer")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
+		let token = PasetoBuilder::new()
+			.set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+			.set_issued_at(None)
+			.set_expiration(&dt)
+			.set_issuer("issuer")
+			.set_audience("audience")
+			.set_jti("jti")
+			.set_not_before(&(Utc::now() + Duration::days(1)))
+			.set_subject("test")
+			.set_claim("claim", json!("data"))
+			.set_footer("footer")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
 
-    let _error: failure::Error = (GenericError::InvalidNotBeforeToken {}).into();
+		let _error: PasetoError = (GenericError::InvalidNotBeforeToken {}).into();
 
-    assert!(matches!(
-      validate_local_token(
-        &token,
-        Some("footer"),
-        &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
-        &TimeBackend::Chrono
-      ),
-      Err(_error)
-    ));
-  }
+		assert!(matches!(
+			validate_local_token(
+				&token,
+				Some("footer"),
+				&"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+				&TimeBackend::Chrono
+			),
+			Err(_error)
+		));
+	}
 
-  #[test]
-  #[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  fn invalid_enc_token_doesnt_validate() {
-    let current_date_time = Utc::now();
-    let dt = Utc.ymd(current_date_time.year() - 1, 7, 8).and_hms(9, 10, 11);
+	#[test]
+	#[cfg(all(feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
+	fn invalid_enc_token_doesnt_validate() {
+		let current_date_time = Utc::now();
+		let dt = Utc
+			.ymd(current_date_time.year() - 1, 7, 8)
+			.and_hms(9, 10, 11);
 
-    let token = PasetoBuilder::new()
-      .set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
-      .set_issued_at(None)
-      .set_expiration(&dt)
-      .set_issuer("issuer")
-      .set_audience("audience")
-      .set_jti("jti")
-      .set_not_before(&Utc::now())
-      .set_subject("test")
-      .set_claim("claim", json!("data"))
-      .set_footer("footer")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
+		let token = PasetoBuilder::new()
+			.set_encryption_key(&Vec::from("YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes()))
+			.set_issued_at(None)
+			.set_expiration(&dt)
+			.set_issuer("issuer")
+			.set_audience("audience")
+			.set_jti("jti")
+			.set_not_before(&Utc::now())
+			.set_subject("test")
+			.set_claim("claim", json!("data"))
+			.set_footer("footer")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
 
-    assert!(validate_local_token(
-      &token,
-      Some("footer"),
-      &"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
-      &TimeBackend::Chrono
-    )
-    .is_err());
-  }
+		assert!(validate_local_token(
+			&token,
+			Some("footer"),
+			&"YELLOW SUBMARINE, BLACK WIZARDRY".as_bytes(),
+			&TimeBackend::Chrono
+		)
+		.is_err());
+	}
 
-  #[test]
-  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  fn valid_pub_token_passes_test() {
-    let current_date_time = Utc::now();
-    let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+	#[test]
+	#[cfg(all(
+		feature = "v2",
+		feature = "easy_tokens_chrono",
+		not(feature = "easy_tokens_time")
+	))]
+	fn valid_pub_token_passes_test() {
+		let current_date_time = Utc::now();
+		let dt = Utc
+			.ymd(current_date_time.year() + 1, 7, 8)
+			.and_hms(9, 10, 11);
 
-    let sys_rand = SystemRandom::new();
-    let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
-    let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+		let sys_rand = SystemRandom::new();
+		let key_pkcs8 =
+			Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+		let as_key =
+			Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
-    let token = PasetoBuilder::new()
-      .set_ed25519_key(&as_key)
-      .set_issued_at(None)
-      .set_expiration(&dt)
-      .set_issuer("issuer")
-      .set_audience("audience")
-      .set_jti("jti")
-      .set_not_before(&Utc::now())
-      .set_subject("test")
-      .set_claim("claim", json!("data"))
-      .set_footer("footer")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
+		let token = PasetoBuilder::new()
+			.set_ed25519_key(&as_key)
+			.set_issued_at(None)
+			.set_expiration(&dt)
+			.set_issuer("issuer")
+			.set_audience("audience")
+			.set_jti("jti")
+			.set_not_before(&Utc::now())
+			.set_subject("test")
+			.set_claim("claim", json!("data"))
+			.set_footer("footer")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
 
-    validate_public_token(
-      &token,
-      Some("footer"),
-      &PasetoPublicKey::ED25519KeyPair(&as_key),
-      &TimeBackend::Chrono,
-    )
-    .expect("Failed to validate token!");
-  }
+		validate_public_token(
+			&token,
+			Some("footer"),
+			&PasetoPublicKey::ED25519KeyPair(&as_key),
+			&TimeBackend::Chrono,
+		)
+		.expect("Failed to validate token!");
+	}
 
-  #[test]
-  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  fn validate_pub_key_only_v2() {
-    let current_date_time = Utc::now();
-    let dt = Utc.ymd(current_date_time.year() + 1, 7, 8).and_hms(9, 10, 11);
+	#[test]
+	#[cfg(all(
+		feature = "v2",
+		feature = "easy_tokens_chrono",
+		not(feature = "easy_tokens_time")
+	))]
+	fn validate_pub_key_only_v2() {
+		let current_date_time = Utc::now();
+		let dt = Utc
+			.ymd(current_date_time.year() + 1, 7, 8)
+			.and_hms(9, 10, 11);
 
-    let sys_rand = SystemRandom::new();
-    let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
-    let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+		let sys_rand = SystemRandom::new();
+		let key_pkcs8 =
+			Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+		let as_key =
+			Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
-    let token = PasetoBuilder::new()
-      .set_ed25519_key(&as_key)
-      .set_issued_at(None)
-      .set_expiration(&dt)
-      .set_issuer("issuer")
-      .set_audience("audience")
-      .set_jti("jti")
-      .set_not_before(&Utc::now())
-      .set_subject("test")
-      .set_claim("claim", json!("data"))
-      .set_footer("footer")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
+		let token = PasetoBuilder::new()
+			.set_ed25519_key(&as_key)
+			.set_issued_at(None)
+			.set_expiration(&dt)
+			.set_issuer("issuer")
+			.set_audience("audience")
+			.set_jti("jti")
+			.set_not_before(&Utc::now())
+			.set_subject("test")
+			.set_claim("claim", json!("data"))
+			.set_footer("footer")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
 
-    validate_public_token(
-      &token,
-      Some("footer"),
-      &PasetoPublicKey::ED25519PublicKey(as_key.public_key().as_ref()),
-      &TimeBackend::Chrono,
-    )
-    .expect("Failed to validate token!");
-  }
+		validate_public_token(
+			&token,
+			Some("footer"),
+			&PasetoPublicKey::ED25519PublicKey(as_key.public_key().as_ref()),
+			&TimeBackend::Chrono,
+		)
+		.expect("Failed to validate token!");
+	}
 
-  #[test]
-  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  fn invalid_pub_token_doesnt_validate() {
-    let current_date_time = Utc::now();
-    let dt = Utc.ymd(current_date_time.year() - 1, 7, 8).and_hms(9, 10, 11);
+	#[test]
+	#[cfg(all(
+		feature = "v2",
+		feature = "easy_tokens_chrono",
+		not(feature = "easy_tokens_time")
+	))]
+	fn invalid_pub_token_doesnt_validate() {
+		let current_date_time = Utc::now();
+		let dt = Utc
+			.ymd(current_date_time.year() - 1, 7, 8)
+			.and_hms(9, 10, 11);
 
-    let sys_rand = SystemRandom::new();
-    let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
-    let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+		let sys_rand = SystemRandom::new();
+		let key_pkcs8 =
+			Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+		let as_key =
+			Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
-    let token = PasetoBuilder::new()
-      .set_ed25519_key(&as_key)
-      .set_issued_at(None)
-      .set_expiration(&dt)
-      .set_issuer("issuer")
-      .set_audience("audience")
-      .set_jti("jti")
-      .set_not_before(&Utc::now())
-      .set_subject("test")
-      .set_claim("claim", json!("data"))
-      .set_footer("footer")
-      .build()
-      .expect("Failed to construct paseto token w/ builder!");
+		let token = PasetoBuilder::new()
+			.set_ed25519_key(&as_key)
+			.set_issued_at(None)
+			.set_expiration(&dt)
+			.set_issuer("issuer")
+			.set_audience("audience")
+			.set_jti("jti")
+			.set_not_before(&Utc::now())
+			.set_subject("test")
+			.set_claim("claim", json!("data"))
+			.set_footer("footer")
+			.build()
+			.expect("Failed to construct paseto token w/ builder!");
 
-    assert!(validate_public_token(
-      &token,
-      Some("footer"),
-      &PasetoPublicKey::ED25519KeyPair(&as_key),
-      &TimeBackend::Chrono
-    )
-    .is_err());
-  }
+		assert!(validate_public_token(
+			&token,
+			Some("footer"),
+			&PasetoPublicKey::ED25519KeyPair(&as_key),
+			&TimeBackend::Chrono
+		)
+		.is_err());
+	}
 
-  #[test]
-  #[cfg(all(feature = "v2", feature = "easy_tokens_chrono", not(feature = "easy_tokens_time")))]
-  fn allows_validation_without_iat_exp_nbf() {
-    let key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
-    let state = PasetoBuilder::new()
-      .set_encryption_key(key.as_bytes())
-      .build()
-      .expect("failed to construct paseto token");
+	#[test]
+	#[cfg(all(
+		feature = "v2",
+		feature = "easy_tokens_chrono",
+		not(feature = "easy_tokens_time")
+	))]
+	fn allows_validation_without_iat_exp_nbf() {
+		let key = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+		let state = PasetoBuilder::new()
+			.set_encryption_key(key.as_bytes())
+			.build()
+			.expect("failed to construct paseto token");
 
-    assert!(
-      validate_local_token(&state, None, key.as_bytes(), &TimeBackend::Chrono).is_ok(),
-      "Failed to validate token without nbf/iat/exp is okay!"
-    );
-  }
+		assert!(
+			validate_local_token(&state, None, key.as_bytes(), &TimeBackend::Chrono).is_ok(),
+			"Failed to validate token without nbf/iat/exp is okay!"
+		);
+	}
 }

--- a/src/v1/get_nonce.rs
+++ b/src/v1/get_nonce.rs
@@ -1,39 +1,41 @@
-//! An implementation of "get_nonce" for version one of paseto tokens.
+//! An implementation of `get_nonce` for version one of paseto tokens.
 
 use ring::hmac::{sign, Key, HMAC_SHA384};
 
-/// An implementation of "get_nonce" from the docs in paseto version one.
+/// An implementation of `get_nonce` from the docs in paseto version one.
 ///
 /// This function is to ensure that an RNG failure does not result in a
 /// nonce-misuse condition that breaks the security of our stream cipher.
+#[must_use]
 pub fn calculate_hashed_nonce(msg: &[u8], random_nonce: &[u8]) -> Vec<u8> {
-  let mac_key = Key::new(HMAC_SHA384, random_nonce);
-  let signed = sign(&mac_key, msg);
-  Vec::from(&signed.as_ref()[0..32])
+	let mac_key = Key::new(HMAC_SHA384, random_nonce);
+	let signed = sign(&mac_key, msg);
+	Vec::from(&signed.as_ref()[0..32])
 }
 
 #[cfg(test)]
 mod unit_tests {
-  use super::*;
-  use hex;
+	use super::*;
+	use hex;
 
-  #[test]
-  fn test_nonce_derivation() {
-    // Constants copied directly from paseto source.
-    let msg_a = "The quick brown fox jumped over the lazy dog.";
-    let msg_b = "The quick brown fox jumped over the lazy dof.";
-    let nonce = hex::decode("808182838485868788898a8b8c8d8e8f").expect("Failed to decode nonce!");
+	#[test]
+	fn test_nonce_derivation() {
+		// Constants copied directly from paseto source.
+		let msg_a = "The quick brown fox jumped over the lazy dog.";
+		let msg_b = "The quick brown fox jumped over the lazy dof.";
+		let nonce =
+			hex::decode("808182838485868788898a8b8c8d8e8f").expect("Failed to decode nonce!");
 
-    let calculated_nonce_a = calculate_hashed_nonce(msg_a.as_bytes(), &nonce);
-    let calculated_nonce_b = calculate_hashed_nonce(msg_b.as_bytes(), &nonce);
+		let calculated_nonce_a = calculate_hashed_nonce(msg_a.as_bytes(), &nonce);
+		let calculated_nonce_b = calculate_hashed_nonce(msg_b.as_bytes(), &nonce);
 
-    assert_eq!(
-      "5e13b4f0fc111bf0cf9de4e97310b687858b51547e125790513cc1eaaef173cc",
-      hex::encode(&calculated_nonce_a)
-    );
-    assert_eq!(
-      "e1ba992f5cccd31714fd8c73adcdadabb00d0f23955a66907170c10072d66ffd",
-      hex::encode(&calculated_nonce_b)
-    )
-  }
+		assert_eq!(
+			"5e13b4f0fc111bf0cf9de4e97310b687858b51547e125790513cc1eaaef173cc",
+			hex::encode(&calculated_nonce_a)
+		);
+		assert_eq!(
+			"e1ba992f5cccd31714fd8c73adcdadabb00d0f23955a66907170c10072d66ffd",
+			hex::encode(&calculated_nonce_b)
+		)
+	}
 }

--- a/src/v1/key_wrapper.rs
+++ b/src/v1/key_wrapper.rs
@@ -8,15 +8,15 @@ use ring::hkdf;
 pub struct CustomKeyWrapper<T>(pub T);
 
 impl hkdf::KeyType for CustomKeyWrapper<usize> {
-  fn len(&self) -> usize {
-    self.0
-  }
+	fn len(&self) -> usize {
+		self.0
+	}
 }
 
 impl From<hkdf::Okm<'_, CustomKeyWrapper<usize>>> for CustomKeyWrapper<Vec<u8>> {
-  fn from(okm: hkdf::Okm<CustomKeyWrapper<usize>>) -> Self {
-    let mut r = vec![0u8; okm.len().0];
-    okm.fill(&mut r).unwrap();
-    CustomKeyWrapper(r)
-  }
+	fn from(okm: hkdf::Okm<CustomKeyWrapper<usize>>) -> Self {
+		let mut r = vec![0_u8; okm.len().0];
+		okm.fill(&mut r).unwrap();
+		CustomKeyWrapper(r)
+	}
 }

--- a/src/v1/local.rs
+++ b/src/v1/local.rs
@@ -1,12 +1,12 @@
 //! An implementation of paseto v1 "local" tokens, or tokens encrypted using a shared secret.
 
-use crate::errors::{GenericError, SodiumErrors};
-use crate::pae::pae;
-use crate::v1::get_nonce::calculate_hashed_nonce;
-use crate::v1::key_wrapper::CustomKeyWrapper;
+use crate::{
+	errors::{GenericError, PasetoError, SodiumErrors},
+	pae::pae,
+	v1::{get_nonce::calculate_hashed_nonce, key_wrapper::CustomKeyWrapper},
+};
 
 use base64::{decode_config, encode_config, URL_SAFE_NO_PAD};
-use failure::Error;
 use openssl::symm;
 use ring::constant_time::verify_slices_are_equal as ConstantTimeEquals;
 use ring::hkdf::{Salt, HKDF_SHA384};
@@ -21,21 +21,26 @@ const HEADER: &str = "v1.local.";
 /// algorithim.
 ///
 /// Returns a result of a string if encryption was successful.
-pub fn local_paseto(msg: &str, footer: Option<&str>, key: &[u8]) -> Result<String, Error> {
-  let rng = SystemRandom::new();
-  let mut buff: [u8; 32] = [0u8; 32];
-  let res = rng.fill(&mut buff);
-  if res.is_err() {
-    return Err(GenericError::RandomError {})?;
-  }
-  if key.len() != 32 {
-    return Err(SodiumErrors::InvalidKeySize {
-      size_needed: 32,
-      size_provided: key.len(),
-    })?;
-  }
+///
+/// # Errors
+///
+/// If random generation of a nonce failed, or encrypting the data failed.
+pub fn local_paseto(msg: &str, footer: Option<&str>, key: &[u8]) -> Result<String, PasetoError> {
+	let rng = SystemRandom::new();
+	let mut buff: [u8; 32] = [0_u8; 32];
+	let res = rng.fill(&mut buff);
+	if res.is_err() {
+		return Err(PasetoError::GenericError(GenericError::RandomError {}));
+	}
+	if key.len() != 32 {
+		return Err(SodiumErrors::InvalidKeySize {
+			size_needed: 32,
+			size_provided: key.len(),
+		}
+		.into());
+	}
 
-  underlying_local_paseto(msg, footer, &buff, key)
+	underlying_local_paseto(msg, footer, &buff, key)
 }
 
 /// Performs the underlying encryption of a paseto token.
@@ -44,57 +49,71 @@ pub fn local_paseto(msg: &str, footer: Option<&str>, key: &[u8]) -> Result<Strin
 /// `footer` - The optional footer.
 /// `random_nonce` - The random nonce.
 /// `key` - The key used for encryption.
-fn underlying_local_paseto(msg: &str, footer: Option<&str>, random_nonce: &[u8], key: &[u8]) -> Result<String, Error> {
-  let footer_frd = footer.unwrap_or("");
-  let true_nonce = calculate_hashed_nonce(msg.as_bytes(), random_nonce);
+fn underlying_local_paseto(
+	msg: &str,
+	footer: Option<&str>,
+	random_nonce: &[u8],
+	key: &[u8],
+) -> Result<String, PasetoError> {
+	let footer_frd = footer.unwrap_or("");
+	let true_nonce = calculate_hashed_nonce(msg.as_bytes(), random_nonce);
 
-  let (as_salt, ctr_nonce) = true_nonce.split_at(16);
-  let hkdf_salt = Salt::new(HKDF_SHA384, as_salt);
+	let (as_salt, ctr_nonce) = true_nonce.split_at(16);
+	let hkdf_salt = Salt::new(HKDF_SHA384, as_salt);
 
-  let mut ek = [0; 32];
-  let mut ak = [0; 32];
+	let mut ek = [0; 32];
+	let mut ak = [0; 32];
 
-  let ek_info = ["paseto-encryption-key".as_bytes()];
-  let ak_info = ["paseto-auth-key-for-aead".as_bytes()];
+	let encryptionkey_info = ["paseto-encryption-key".as_bytes()];
+	let authkey_info = ["paseto-auth-key-for-aead".as_bytes()];
 
-  let extracted = hkdf_salt.extract(key);
-  let ek_result = extracted.expand(&ek_info, CustomKeyWrapper(32));
-  let ak_result = extracted.expand(&ak_info, CustomKeyWrapper(32));
-  if ek_result.is_err() || ak_result.is_err() {
-    return Err(GenericError::BadHkdf {})?;
-  }
-  let ek_fill_result = ek_result.unwrap().fill(&mut ek);
-  let ak_fill_result = ak_result.unwrap().fill(&mut ak);
-  if ek_fill_result.is_err() || ak_fill_result.is_err() {
-    return Err(GenericError::BadHkdf {})?;
-  }
+	let extracted = hkdf_salt.extract(key);
+	let encryptionkey_wrapped_res = extracted.expand(&encryptionkey_info, CustomKeyWrapper(32));
+	let authkey_wrapped_res = extracted.expand(&authkey_info, CustomKeyWrapper(32));
+	if encryptionkey_wrapped_res.is_err() || authkey_wrapped_res.is_err() {
+		return Err(GenericError::BadHkdf {}.into());
+	}
+	let encryptionkey_fill_res = encryptionkey_wrapped_res.unwrap().fill(&mut ek);
+	let accesskey_fill_res = authkey_wrapped_res.unwrap().fill(&mut ak);
+	if encryptionkey_fill_res.is_err() || accesskey_fill_res.is_err() {
+		return Err(GenericError::BadHkdf {}.into());
+	}
 
-  let cipher = symm::Cipher::aes_256_ctr();
-  let crypted = symm::encrypt(cipher, &ek, Some(&ctr_nonce), msg.as_bytes())?;
+	let cipher = symm::Cipher::aes_256_ctr();
+	let crypted = symm::encrypt(cipher, &ek, Some(ctr_nonce), msg.as_bytes())?;
 
-  let pre_auth = pae(&[HEADER.as_bytes(), &true_nonce, &crypted, footer_frd.as_bytes()]);
+	let pre_auth = pae(&[
+		HEADER.as_bytes(),
+		&true_nonce,
+		&crypted,
+		footer_frd.as_bytes(),
+	]);
 
-  let mac_key = Key::new(HMAC_SHA384, &ak);
-  let signed = sign(&mac_key, &pre_auth);
-  let raw_bytes_from_hmac = signed.as_ref();
+	let mac_key = Key::new(HMAC_SHA384, &ak);
+	let signed = sign(&mac_key, &pre_auth);
+	let raw_bytes_from_hmac = signed.as_ref();
 
-  let mut concated_together = Vec::new();
-  concated_together.extend_from_slice(&true_nonce);
-  concated_together.extend_from_slice(&crypted);
-  concated_together.extend_from_slice(&raw_bytes_from_hmac);
+	let mut concated_together = Vec::new();
+	concated_together.extend_from_slice(&true_nonce);
+	concated_together.extend_from_slice(&crypted);
+	concated_together.extend_from_slice(raw_bytes_from_hmac);
 
-  let token = if footer_frd.is_empty() {
-    format!("{}{}", HEADER, encode_config(&concated_together, URL_SAFE_NO_PAD))
-  } else {
-    format!(
-      "{}{}.{}",
-      HEADER,
-      encode_config(&concated_together, URL_SAFE_NO_PAD),
-      encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
-    )
-  };
+	let token = if footer_frd.is_empty() {
+		format!(
+			"{}{}",
+			HEADER,
+			encode_config(&concated_together, URL_SAFE_NO_PAD)
+		)
+	} else {
+		format!(
+			"{}{}.{}",
+			HEADER,
+			encode_config(&concated_together, URL_SAFE_NO_PAD),
+			encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
+		)
+	};
 
-  Ok(token)
+	Ok(token)
 }
 
 /// Decrypt a version 1 paseto token.
@@ -102,140 +121,154 @@ fn underlying_local_paseto(msg: &str, footer: Option<&str>, random_nonce: &[u8],
 /// `token` - The encrypted token.
 /// `footer` - The optional footer to validate against.
 /// `key` - The key used to encrypt the token.
-pub fn decrypt_paseto(token: &str, footer: Option<&str>, key: &[u8]) -> Result<String, Error> {
-  let token_parts = token.split(".").collect::<Vec<_>>();
-  if token_parts.len() < 3 {
-    return Err(GenericError::InvalidToken {})?;
-  }
+///
+/// # Errors
+///
+/// If the token is invalid in anyway, and cannot be decrypted.
+pub fn decrypt_paseto(
+	token: &str,
+	footer: Option<&str>,
+	key: &[u8],
+) -> Result<String, PasetoError> {
+	let token_parts = token.split('.').collect::<Vec<_>>();
+	if token_parts.len() < 3 {
+		return Err(GenericError::InvalidToken {}.into());
+	}
 
-  let is_footer_some = footer.is_some();
-  let footer_str = footer.unwrap_or("");
+	let is_footer_some = footer.is_some();
+	let footer_str = footer.unwrap_or("");
 
-  if is_footer_some {
-    if token_parts.len() < 4 {
-      return Err(GenericError::InvalidFooter {})?;
-    }
-    let as_base64 = encode_config(footer_str.as_bytes(), URL_SAFE_NO_PAD);
+	if is_footer_some {
+		if token_parts.len() < 4 {
+			return Err(GenericError::InvalidFooter {}.into());
+		}
+		let as_base64 = encode_config(footer_str.as_bytes(), URL_SAFE_NO_PAD);
 
-    if ConstantTimeEquals(as_base64.as_bytes(), token_parts[3].as_bytes()).is_err() {
-      return Err(GenericError::InvalidFooter {})?;
-    }
-  }
+		if ConstantTimeEquals(as_base64.as_bytes(), token_parts[3].as_bytes()).is_err() {
+			return Err(GenericError::InvalidFooter {}.into());
+		}
+	}
 
-  if token_parts[0] != "v1" || token_parts[1] != "local" {
-    return Err(GenericError::InvalidToken {})?;
-  }
-  let decoded = decode_config(token_parts[2].as_bytes(), URL_SAFE_NO_PAD)?;
-  let (nonce, t_and_c) = decoded.split_at(32);
-  // NLL :shakefists:
-  let t_and_c_vec = Vec::from(t_and_c);
-  let t_and_c_len = t_and_c_vec.len();
-  let (ciphertext, mac) = t_and_c_vec.split_at(t_and_c_len - 48);
+	if token_parts[0] != "v1" || token_parts[1] != "local" {
+		return Err(GenericError::InvalidToken {}.into());
+	}
+	let decoded = decode_config(token_parts[2].as_bytes(), URL_SAFE_NO_PAD)
+		.map_err(|e| PasetoError::GenericError(GenericError::Base64Error(e)))?;
+	let (nonce, t_and_c) = decoded.split_at(32);
+	// NLL :shakefists:
+	let t_and_c_vec = Vec::from(t_and_c);
+	let t_and_c_len = t_and_c_vec.len();
+	let (ciphertext, mac) = t_and_c_vec.split_at(t_and_c_len - 48);
 
-  let nonce = Vec::from(nonce);
-  let (as_salt, ctr_nonce) = nonce.split_at(16);
-  let hkdf_salt = Salt::new(HKDF_SHA384, as_salt);
+	let nonce = Vec::from(nonce);
+	let (as_salt, ctr_nonce) = nonce.split_at(16);
+	let hkdf_salt = Salt::new(HKDF_SHA384, as_salt);
 
-  let mut ek = [0; 32];
-  let mut ak = [0; 32];
+	let mut ek = [0; 32];
+	let mut ak = [0; 32];
 
-  let extracted = hkdf_salt.extract(key);
-  let ek_info = ["paseto-encryption-key".as_bytes()];
-  let ak_info = ["paseto-auth-key-for-aead".as_bytes()];
+	let extracted = hkdf_salt.extract(key);
+	let encryptionkey_info = ["paseto-encryption-key".as_bytes()];
+	let authkey_info = ["paseto-auth-key-for-aead".as_bytes()];
 
-  let ek_result = extracted.expand(&ek_info, CustomKeyWrapper(32));
-  let ak_result = extracted.expand(&ak_info, CustomKeyWrapper(32));
-  if ek_result.is_err() || ak_result.is_err() {
-    return Err(GenericError::BadHkdf {})?;
-  }
-  let ek_fill_result = ek_result.unwrap().fill(&mut ek);
-  let ak_fill_result = ak_result.unwrap().fill(&mut ak);
-  if ek_fill_result.is_err() || ak_fill_result.is_err() {
-    return Err(GenericError::BadHkdf {})?;
-  }
+	let encryptionkey_wrapped_res = extracted
+		.expand(&encryptionkey_info, CustomKeyWrapper(32))
+		.map_err(|_| GenericError::BadHkdf {})?;
+	let authkey_wrapped_res = extracted
+		.expand(&authkey_info, CustomKeyWrapper(32))
+		.map_err(|_| GenericError::BadHkdf {})?;
+	encryptionkey_wrapped_res
+		.fill(&mut ek)
+		.map_err(|_| GenericError::BadHkdf {})?;
+	authkey_wrapped_res
+		.fill(&mut ak)
+		.map_err(|_| GenericError::BadHkdf {})?;
 
-  let pre_auth = pae(&[HEADER.as_bytes(), &nonce, ciphertext, footer_str.as_bytes()]);
+	let pre_auth = pae(&[HEADER.as_bytes(), &nonce, ciphertext, footer_str.as_bytes()]);
 
-  let mac_key = Key::new(HMAC_SHA384, &ak);
-  let signed = sign(&mac_key, &pre_auth);
-  let raw_bytes_from_hmac = signed.as_ref();
+	let mac_key = Key::new(HMAC_SHA384, &ak);
+	let signed = sign(&mac_key, &pre_auth);
+	let raw_bytes_from_hmac = signed.as_ref();
 
-  if ConstantTimeEquals(&raw_bytes_from_hmac, mac).is_err() {
-    return Err(GenericError::InvalidToken {})?;
-  }
+	if ConstantTimeEquals(raw_bytes_from_hmac, mac).is_err() {
+		return Err(GenericError::InvalidToken {}.into());
+	}
 
-  let cipher = symm::Cipher::aes_256_ctr();
-  let decrypted = symm::decrypt(cipher, &ek, Some(ctr_nonce), ciphertext)?;
+	let cipher = symm::Cipher::aes_256_ctr();
+	let decrypted = symm::decrypt(cipher, &ek, Some(ctr_nonce), ciphertext)?;
 
-  Ok(String::from_utf8(decrypted)?)
+	String::from_utf8(decrypted).map_err(|e| PasetoError::GenericError(GenericError::Utf8Error(e)))
 }
 
 #[cfg(test)]
 mod unit_tests {
-  use super::*;
-  use ring::rand::{SecureRandom, SystemRandom};
+	use super::*;
+	use ring::rand::{SecureRandom, SystemRandom};
 
-  #[test]
-  fn test_v1_local() {
-    let rng = SystemRandom::new();
-    let mut key_buff: [u8; 32] = [0u8; 32];
-    rng.fill(&mut key_buff).expect("Failed to fill key_buff!");
+	#[test]
+	fn test_v1_local() {
+		let rng = SystemRandom::new();
+		let mut key_buff: [u8; 32] = [0_u8; 32];
+		rng.fill(&mut key_buff).expect("Failed to fill key_buff!");
 
-    // Try to encrypt without footers.
-    let message_a = local_paseto("msg", None, &key_buff).expect("Failed to encrypt V1 Paseto string");
-    // NOTE: This test is just ensuring we can encode a json object, remember these internal impls
-    // don't check for expires being valid!
-    let message_b = local_paseto(
-      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
-      None,
-      &key_buff,
-    )
-    .expect("Failed to encrypt V1 Paseto Json BLOB");
+		// Try to encrypt without footers.
+		let message_a =
+			local_paseto("msg", None, &key_buff).expect("Failed to encrypt V1 Paseto string");
+		// NOTE: This test is just ensuring we can encode a json object, remember these internal impls
+		// don't check for expires being valid!
+		let message_b = local_paseto(
+			"{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
+			None,
+			&key_buff,
+		)
+		.expect("Failed to encrypt V1 Paseto Json BLOB");
 
-    assert!(message_a.starts_with("v1.local."));
-    assert!(message_b.starts_with("v1.local."));
+		assert!(message_a.starts_with("v1.local."));
+		assert!(message_b.starts_with("v1.local."));
 
-    let decrypted_a = decrypt_paseto(&message_a, None, &key_buff).expect("Failed to decrypt V1 Paseto String");
-    let decrypted_b = decrypt_paseto(&message_b, None, &key_buff).expect("Failed to decrypt V1 Paseto JSON Blob");
+		let decrypted_a = decrypt_paseto(&message_a, None, &key_buff)
+			.expect("Failed to decrypt V1 Paseto String");
+		let decrypted_b = decrypt_paseto(&message_b, None, &key_buff)
+			.expect("Failed to decrypt V1 Paseto JSON Blob");
 
-    assert_eq!(decrypted_a, "msg");
-    assert_eq!(
-      decrypted_b,
-      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"
-    );
+		assert_eq!(decrypted_a, "msg");
+		assert_eq!(
+			decrypted_b,
+			"{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"
+		);
 
-    let should_fail_decryption_a = decrypt_paseto(&message_a, Some("data"), &key_buff);
-    assert!(should_fail_decryption_a.is_err());
+		let should_fail_decryption_a = decrypt_paseto(&message_a, Some("data"), &key_buff);
+		assert!(should_fail_decryption_a.is_err());
 
-    // Try with footers.
-    let message_c =
-      local_paseto("msg", Some("data"), &key_buff).expect("Failed to encrypt V1 Paseto String with footer!");
-    let message_d = local_paseto(
-      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
-      Some("data"),
-      &key_buff,
-    )
-    .expect("Failed to encrypt V1 Paseto Json blob with footer!");
+		// Try with footers.
+		let message_c = local_paseto("msg", Some("data"), &key_buff)
+			.expect("Failed to encrypt V1 Paseto String with footer!");
+		let message_d = local_paseto(
+			"{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
+			Some("data"),
+			&key_buff,
+		)
+		.expect("Failed to encrypt V1 Paseto Json blob with footer!");
 
-    assert!(message_c.starts_with("v1.local."));
-    assert!(message_d.starts_with("v1.local."));
+		assert!(message_c.starts_with("v1.local."));
+		assert!(message_d.starts_with("v1.local."));
 
-    let decrypted_c =
-      decrypt_paseto(&message_c, Some("data"), &key_buff).expect("Failed to decrypt V1 Paseto String with footer!");
-    let decrypted_d =
-      decrypt_paseto(&message_d, Some("data"), &key_buff).expect("Failed to decrypt V1 Paseto Json Blob with footer!");
+		let decrypted_c = decrypt_paseto(&message_c, Some("data"), &key_buff)
+			.expect("Failed to decrypt V1 Paseto String with footer!");
+		let decrypted_d = decrypt_paseto(&message_d, Some("data"), &key_buff)
+			.expect("Failed to decrypt V1 Paseto Json Blob with footer!");
 
-    assert_eq!(decrypted_c, "msg");
-    assert_eq!(
-      decrypted_d,
-      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"
-    );
+		assert_eq!(decrypted_c, "msg");
+		assert_eq!(
+			decrypted_d,
+			"{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"
+		);
 
-    // Try with no footer + invalid footer.
-    let should_fail_decryption_b = decrypt_paseto(&message_c, None, &key_buff);
-    let should_fail_decryption_c = decrypt_paseto(&message_c, Some("invalid"), &key_buff);
+		// Try with no footer + invalid footer.
+		let should_fail_decryption_b = decrypt_paseto(&message_c, None, &key_buff);
+		let should_fail_decryption_c = decrypt_paseto(&message_c, Some("invalid"), &key_buff);
 
-    assert!(should_fail_decryption_b.is_err());
-    assert!(should_fail_decryption_c.is_err());
-  }
+		assert!(should_fail_decryption_b.is_err());
+		assert!(should_fail_decryption_c.is_err());
+	}
 }

--- a/src/v1/public.rs
+++ b/src/v1/public.rs
@@ -1,11 +1,12 @@
 //! An implementation of Paseto v1 "public" tokens, or tokens that
 //! are signed with a public/private key pair.
 
-use crate::errors::{GenericError, RsaKeyErrors};
-use crate::pae::pae;
+use crate::{
+	errors::{GenericError, PasetoError, RsaKeyErrors},
+	pae::pae,
+};
 
 use base64::{decode_config, encode_config, URL_SAFE_NO_PAD};
-use failure::Error;
 use ring::constant_time::verify_slices_are_equal as ConstantTimeEquals;
 use ring::rand::SystemRandom;
 use ring::signature::{RsaKeyPair, UnparsedPublicKey, RSA_PSS_2048_8192_SHA384, RSA_PSS_SHA384};
@@ -15,145 +16,167 @@ const HEADER: &str = "v1.public.";
 /// Sign a "v1.public" paseto token.
 ///
 /// Returns a result of a string if signing was successful.
-pub fn public_paseto(msg: &str, footer: Option<&str>, key_pair: &RsaKeyPair) -> Result<String, Error> {
-  if key_pair.public_modulus_len() != 256 {
-    return Err(RsaKeyErrors::InvalidKey {})?;
-  }
-  let footer_frd = footer.unwrap_or("");
+///
+/// # Errors
+///
+/// If there was a failure signing the data.
+pub fn public_paseto(
+	msg: &str,
+	footer: Option<&str>,
+	key_pair: &RsaKeyPair,
+) -> Result<String, PasetoError> {
+	if key_pair.public_modulus_len() != 256 {
+		return Err(RsaKeyErrors::InvalidKey {}.into());
+	}
+	let footer_frd = footer.unwrap_or("");
 
-  let pre_auth = pae(&[HEADER.as_bytes(), msg.as_bytes(), footer_frd.as_bytes()]);
-  let random = SystemRandom::new();
+	let pre_auth = pae(&[HEADER.as_bytes(), msg.as_bytes(), footer_frd.as_bytes()]);
+	let random = SystemRandom::new();
 
-  let mut signed_msg = [0; 256];
-  let sign_res = key_pair.sign(&RSA_PSS_SHA384, &random, &pre_auth, &mut signed_msg);
-  if sign_res.is_err() {
-    return Err(RsaKeyErrors::SignError {})?;
-  }
+	let mut signed_msg = [0; 256];
+	let sign_res = key_pair.sign(&RSA_PSS_SHA384, &random, &pre_auth, &mut signed_msg);
+	if sign_res.is_err() {
+		return Err(RsaKeyErrors::SignError {}.into());
+	}
 
-  let mut combined_vec = Vec::new();
-  combined_vec.extend_from_slice(msg.as_bytes());
-  combined_vec.extend_from_slice(&signed_msg);
+	let mut combined_vec = Vec::new();
+	combined_vec.extend_from_slice(msg.as_bytes());
+	combined_vec.extend_from_slice(&signed_msg);
 
-  let token = if footer_frd.is_empty() {
-    format!("{}{}", HEADER, encode_config(&combined_vec, URL_SAFE_NO_PAD))
-  } else {
-    format!(
-      "{}{}.{}",
-      HEADER,
-      encode_config(&combined_vec, URL_SAFE_NO_PAD),
-      encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
-    )
-  };
+	let token = if footer_frd.is_empty() {
+		format!(
+			"{}{}",
+			HEADER,
+			encode_config(&combined_vec, URL_SAFE_NO_PAD)
+		)
+	} else {
+		format!(
+			"{}{}.{}",
+			HEADER,
+			encode_config(&combined_vec, URL_SAFE_NO_PAD),
+			encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
+		)
+	};
 
-  Ok(token)
+	Ok(token)
 }
 
 /// Verifies a "v1.public" paseto token based on a public key
 ///
-/// Returns the message if verification was successful, otherwise an Err().
-pub fn verify_paseto(token: &str, footer: Option<&str>, public_key: &[u8]) -> Result<String, Error> {
-  let token_parts = token.split(".").collect::<Vec<_>>();
-  if token_parts.len() < 3 {
-    return Err(GenericError::InvalidToken {})?;
-  }
+/// Returns the message if verification was successful.
+///
+/// # Errors
+///
+/// If the string passed in was not a valid token, and did not have a correct footer.
+pub fn verify_paseto(
+	token: &str,
+	footer: Option<&str>,
+	public_key: &[u8],
+) -> Result<String, PasetoError> {
+	let token_parts = token.split('.').collect::<Vec<_>>();
+	if token_parts.len() < 3 {
+		return Err(GenericError::InvalidToken {}.into());
+	}
 
-  let has_provided_footer = footer.is_some();
-  let footer_as_str = footer.unwrap_or("");
+	let has_provided_footer = footer.is_some();
+	let footer_as_str = footer.unwrap_or("");
 
-  if has_provided_footer {
-    if token_parts.len() < 4 {
-      return Err(GenericError::InvalidFooter {})?;
-    }
-    let footer_encoded = encode_config(footer_as_str.as_bytes(), URL_SAFE_NO_PAD);
+	if has_provided_footer {
+		if token_parts.len() < 4 {
+			return Err(GenericError::InvalidFooter {}.into());
+		}
+		let footer_encoded = encode_config(footer_as_str.as_bytes(), URL_SAFE_NO_PAD);
 
-    if ConstantTimeEquals(footer_encoded.as_bytes(), token_parts[3].as_bytes()).is_err() {
-      return Err(GenericError::InvalidFooter {})?;
-    }
-  }
+		if ConstantTimeEquals(footer_encoded.as_bytes(), token_parts[3].as_bytes()).is_err() {
+			return Err(GenericError::InvalidFooter {}.into());
+		}
+	}
 
-  if token_parts[0] != "v1" || token_parts[1] != "public" {
-    return Err(GenericError::InvalidToken {})?;
-  }
+	if token_parts[0] != "v1" || token_parts[1] != "public" {
+		return Err(GenericError::InvalidToken {}.into());
+	}
 
-  let decoded = decode_config(token_parts[2].as_bytes(), URL_SAFE_NO_PAD)?;
-  let decoded_len = decoded.len();
-  let (message, sig) = decoded.split_at(decoded_len - 256);
+	let decoded = decode_config(token_parts[2].as_bytes(), URL_SAFE_NO_PAD)
+		.map_err(|e| PasetoError::GenericError(GenericError::Base64Error(e)))?;
+	let decoded_len = decoded.len();
+	let (message, sig) = decoded.split_at(decoded_len - 256);
 
-  let pre_auth = pae(&[HEADER.as_bytes(), message, footer_as_str.as_bytes()]);
+	let pre_auth = pae(&[HEADER.as_bytes(), message, footer_as_str.as_bytes()]);
 
-  let pk_unparsed = UnparsedPublicKey::new(&RSA_PSS_2048_8192_SHA384, public_key);
-  let verify_result = pk_unparsed.verify(&pre_auth, sig);
-  if verify_result.is_err() {
-    return Err(GenericError::InvalidToken {})?;
-  }
+	let pk_unparsed = UnparsedPublicKey::new(&RSA_PSS_2048_8192_SHA384, public_key);
+	let verify_result = pk_unparsed.verify(&pre_auth, sig);
+	if verify_result.is_err() {
+		return Err(GenericError::InvalidToken {}.into());
+	}
 
-  Ok(String::from_utf8(Vec::from(message))?)
+	String::from_utf8(Vec::from(message))
+		.map_err(|e| PasetoError::GenericError(GenericError::Utf8Error(e)))
 }
 
 #[cfg(test)]
 mod unit_tests {
-  use super::*;
+	use super::*;
 
-  use ring::signature::RsaKeyPair;
+	use ring::signature::RsaKeyPair;
 
-  #[test]
-  fn test_v1_public() {
-    let private_key = include_bytes!("signature_rsa_example_private_key.der");
-    let public_key = include_bytes!("signature_rsa_example_public_key.der");
+	#[test]
+	fn test_v1_public() {
+		let private_key = include_bytes!("signature_rsa_example_private_key.der");
+		let public_key = include_bytes!("signature_rsa_example_public_key.der");
 
-    let key_pair = RsaKeyPair::from_der(private_key).expect("Bad Private Key pkcs!");
+		let key_pair = RsaKeyPair::from_der(private_key).expect("Bad Private Key pkcs!");
 
-    // Test keys without footers.
-    let public_token_one =
-      public_paseto("msg", None, &key_pair).expect("Failed to encode public paseto v1 msg with no footer!");
-    // Remember raw protocol doesn't validate expires. We're just ensuring we can encode it.
-    let public_token_two = public_paseto(
-      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
-      None,
-      &key_pair,
-    )
-    .expect("Failed to encode public paseto v1 json blob with no footer!");
+		// Test keys without footers.
+		let public_token_one = public_paseto("msg", None, &key_pair)
+			.expect("Failed to encode public paseto v1 msg with no footer!");
+		// Remember raw protocol doesn't validate expires. We're just ensuring we can encode it.
+		let public_token_two = public_paseto(
+			"{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
+			None,
+			&key_pair,
+		)
+		.expect("Failed to encode public paseto v1 json blob with no footer!");
 
-    let verified_one = verify_paseto(&public_token_one, None, public_key)
-      .expect("Failed to verify public paseto v1 msg with no footer!");
-    let verified_two = verify_paseto(&public_token_two, None, public_key)
-      .expect("Failed to verify public paseto v1 json blob with no footer!");
+		let verified_one = verify_paseto(&public_token_one, None, public_key)
+			.expect("Failed to verify public paseto v1 msg with no footer!");
+		let verified_two = verify_paseto(&public_token_two, None, public_key)
+			.expect("Failed to verify public paseto v1 json blob with no footer!");
 
-    assert_eq!(verified_one, "msg");
-    assert_eq!(
-      verified_two,
-      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"
-    );
+		assert_eq!(verified_one, "msg");
+		assert_eq!(
+			verified_two,
+			"{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"
+		);
 
-    // Attempt to verify with a footer
-    let should_not_verify_one = verify_paseto(&public_token_one, Some("hoi"), public_key);
-    assert!(should_not_verify_one.is_err());
+		// Attempt to verify with a footer
+		let should_not_verify_one = verify_paseto(&public_token_one, Some("hoi"), public_key);
+		assert!(should_not_verify_one.is_err());
 
-    let public_token_three =
-      public_paseto("msg", Some("data"), &key_pair).expect("Failed to encode public paseto v1 msg with footer!");
-    let public_token_four = public_paseto(
-      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
-      Some("data"),
-      &key_pair,
-    )
-    .expect("Failed to encode public paseto v1 json blob with footer!");
+		let public_token_three = public_paseto("msg", Some("data"), &key_pair)
+			.expect("Failed to encode public paseto v1 msg with footer!");
+		let public_token_four = public_paseto(
+			"{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
+			Some("data"),
+			&key_pair,
+		)
+		.expect("Failed to encode public paseto v1 json blob with footer!");
 
-    let verified_three = verify_paseto(&public_token_three, Some("data"), public_key)
-      .expect("Failed to verify public paseto v1 msg with footer!");
-    let verified_four = verify_paseto(&public_token_four, Some("data"), public_key)
-      .expect("Failed to verify public paseto v1 json blob with footer!");
+		let verified_three = verify_paseto(&public_token_three, Some("data"), public_key)
+			.expect("Failed to verify public paseto v1 msg with footer!");
+		let verified_four = verify_paseto(&public_token_four, Some("data"), public_key)
+			.expect("Failed to verify public paseto v1 json blob with footer!");
 
-    assert_eq!(verified_three, "msg");
-    assert_eq!(
-      verified_four,
-      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"
-    );
+		assert_eq!(verified_three, "msg");
+		assert_eq!(
+			verified_four,
+			"{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"
+		);
 
-    // Ensure that no footer + incorrect footer fail to validate.
-    let should_not_verify_two = verify_paseto(&public_token_three, None, public_key);
-    let should_not_verify_three = verify_paseto(&public_token_three, Some("test"), public_key);
+		// Ensure that no footer + incorrect footer fail to validate.
+		let should_not_verify_two = verify_paseto(&public_token_three, None, public_key);
+		let should_not_verify_three = verify_paseto(&public_token_three, Some("test"), public_key);
 
-    assert!(should_not_verify_two.is_err());
-    assert!(should_not_verify_three.is_err());
-  }
+		assert!(should_not_verify_two.is_err());
+		assert!(should_not_verify_three.is_err());
+	}
 }

--- a/src/v2/local.rs
+++ b/src/v2/local.rs
@@ -1,23 +1,22 @@
 //! An Implementation of Paseto V2 "local" tokens (or tokens that are encrypted with a shared secret).
 
 use crate::{
-  errors::{GenericError, SodiumErrors},
-  pae::pae,
+	errors::{GenericError, PasetoError, SodiumErrors},
+	pae::pae,
 };
 
 use base64::{decode_config, encode_config, URL_SAFE_NO_PAD};
 use blake2::{
-  digest::{Update, VariableOutput},
-  VarBlake2b,
+	digest::{Update, VariableOutput},
+	VarBlake2b,
 };
 use chacha20poly1305::{
-  aead::{Aead, NewAead, Payload},
-  XChaCha20Poly1305, XNonce,
+	aead::{Aead, NewAead, Payload},
+	XChaCha20Poly1305, XNonce,
 };
-use failure::Error;
 use ring::{
-  constant_time::verify_slices_are_equal as ConstantTimeEquals,
-  rand::{SecureRandom, SystemRandom},
+	constant_time::verify_slices_are_equal as ConstantTimeEquals,
+	rand::{SecureRandom, SystemRandom},
 };
 
 const HEADER: &str = "v2.local.";
@@ -28,22 +27,27 @@ const HEADER: &str = "v2.local.";
 /// algorithim.
 ///
 /// Returns a result of a string if encryption was successful.
-pub fn local_paseto(msg: &str, footer: Option<&str>, key: &[u8]) -> Result<String, Error> {
-  let rng = SystemRandom::new();
-  let mut buff: [u8; 24] = [0u8; 24];
-  let res = rng.fill(&mut buff);
-  if res.is_err() {
-    return Err(GenericError::RandomError {})?;
-  }
+///
+/// # Errors
+///
+/// If random generation of a nonce failed, or encrypting the data failed.
+pub fn local_paseto(msg: &str, footer: Option<&str>, key: &[u8]) -> Result<String, PasetoError> {
+	let rng = SystemRandom::new();
+	let mut buff: [u8; 24] = [0_u8; 24];
+	let res = rng.fill(&mut buff);
+	if res.is_err() {
+		return Err(GenericError::RandomError {}.into());
+	}
 
-  if key.len() != 32 {
-    return Err(SodiumErrors::InvalidKeySize {
-      size_needed: 32,
-      size_provided: key.len(),
-    })?;
-  }
+	if key.len() != 32 {
+		return Err(SodiumErrors::InvalidKeySize {
+			size_needed: 32,
+			size_provided: key.len(),
+		}
+		.into());
+	}
 
-  underlying_local_paseto(msg, footer, &buff, key)
+	underlying_local_paseto(msg, footer, &buff, key)
 }
 
 /// Performs the underlying encryption of a paseto token. Split for unit testing.
@@ -52,46 +56,52 @@ pub fn local_paseto(msg: &str, footer: Option<&str>, key: &[u8]) -> Result<Strin
 /// `footer` - The footer to add.
 /// `nonce_key` - The key to the nonce, should be securely generated.
 /// `key` - The key to encrypt the message with.
-fn underlying_local_paseto(msg: &str, footer: Option<&str>, nonce_key: &[u8; 24], key: &[u8]) -> Result<String, Error> {
-  let footer_frd = footer.unwrap_or("");
-  let mut state = VarBlake2b::new_keyed(nonce_key, 24);
-  state.update(msg.as_bytes());
-  let finalized = state.finalize_boxed();
-  let nonce = XNonce::from_slice(finalized.as_ref());
-  if let Ok(aead) = XChaCha20Poly1305::new_from_slice(key) {
-    let pre_auth = pae(&[HEADER.as_bytes(), finalized.as_ref(), footer_frd.as_bytes()]);
-    if let Ok(crypted) = aead.encrypt(
-      nonce,
-      Payload {
-        msg: msg.as_bytes(),
-        aad: pre_auth.as_ref(),
-      },
-    ) {
-      let mut n_and_c = Vec::new();
-      n_and_c.extend_from_slice(finalized.as_ref());
-      n_and_c.extend_from_slice(crypted.as_ref());
+fn underlying_local_paseto(
+	msg: &str,
+	footer: Option<&str>,
+	nonce_key: &[u8; 24],
+	key: &[u8],
+) -> Result<String, PasetoError> {
+	let footer_frd = footer.unwrap_or("");
+	let mut state = VarBlake2b::new_keyed(nonce_key, 24);
+	state.update(msg.as_bytes());
+	let finalized = state.finalize_boxed();
+	let nonce = XNonce::from_slice(finalized.as_ref());
+	if let Ok(aead) = XChaCha20Poly1305::new_from_slice(key) {
+		let pre_auth = pae(&[HEADER.as_bytes(), finalized.as_ref(), footer_frd.as_bytes()]);
+		if let Ok(crypted) = aead.encrypt(
+			nonce,
+			Payload {
+				msg: msg.as_bytes(),
+				aad: pre_auth.as_ref(),
+			},
+		) {
+			let mut n_and_c = Vec::new();
+			n_and_c.extend_from_slice(finalized.as_ref());
+			n_and_c.extend_from_slice(crypted.as_ref());
 
-      let token = if !footer_frd.is_empty() {
-        format!(
-          "{}{}.{}",
-          HEADER,
-          encode_config(&n_and_c, URL_SAFE_NO_PAD),
-          encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
-        )
-      } else {
-        format!("{}{}", HEADER, encode_config(&n_and_c, URL_SAFE_NO_PAD))
-      };
+			let token = if footer_frd.is_empty() {
+				format!("{}{}", HEADER, encode_config(&n_and_c, URL_SAFE_NO_PAD))
+			} else {
+				format!(
+					"{}{}.{}",
+					HEADER,
+					encode_config(&n_and_c, URL_SAFE_NO_PAD),
+					encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
+				)
+			};
 
-      Ok(token)
-    } else {
-      return Err(SodiumErrors::FunctionError {})?;
-    }
-  } else {
-    return Err(SodiumErrors::InvalidKeySize {
-      size_provided: key.len(),
-      size_needed: 32,
-    })?;
-  }
+			Ok(token)
+		} else {
+			Err(SodiumErrors::FunctionError {}.into())
+		}
+	} else {
+		Err(SodiumErrors::InvalidKeySize {
+			size_provided: key.len(),
+			size_needed: 32,
+		}
+		.into())
+	}
 }
 
 /// Decrypt a Paseto TOKEN, validating against an optional footer.
@@ -99,177 +109,197 @@ fn underlying_local_paseto(msg: &str, footer: Option<&str>, nonce_key: &[u8; 24]
 /// `token`: The Token to decrypt.
 /// `footer`: The Optional footer to validate.
 /// `key`: The key to decrypt your Paseto.
-pub fn decrypt_paseto(token: &str, footer: Option<&str>, key: &[u8]) -> Result<String, Error> {
-  let token_parts = token.split(".").collect::<Vec<_>>();
-  if token_parts.len() < 3 {
-    return Err(GenericError::InvalidToken {})?;
-  }
+///
+/// # Errors
+///
+/// If the token is invalid in anyway, and cannot be decrypted.
+pub fn decrypt_paseto(
+	token: &str,
+	footer: Option<&str>,
+	key: &[u8],
+) -> Result<String, PasetoError> {
+	let token_parts = token.split('.').collect::<Vec<_>>();
+	if token_parts.len() < 3 {
+		return Err(GenericError::InvalidToken {}.into());
+	}
 
-  let is_footer_some = footer.is_some();
-  let footer_str = footer.unwrap_or("");
+	let is_footer_some = footer.is_some();
+	let footer_str = footer.unwrap_or("");
 
-  if is_footer_some {
-    if token_parts.len() < 4 {
-      return Err(GenericError::InvalidFooter {})?;
-    }
-    let as_base64 = encode_config(footer_str.as_bytes(), URL_SAFE_NO_PAD);
+	if is_footer_some {
+		if token_parts.len() < 4 {
+			return Err(GenericError::InvalidFooter {}.into());
+		}
+		let as_base64 = encode_config(footer_str.as_bytes(), URL_SAFE_NO_PAD);
 
-    if ConstantTimeEquals(as_base64.as_bytes(), token_parts[3].as_bytes()).is_err() {
-      return Err(GenericError::InvalidFooter {})?;
-    }
-  }
+		if ConstantTimeEquals(as_base64.as_bytes(), token_parts[3].as_bytes()).is_err() {
+			return Err(GenericError::InvalidFooter {}.into());
+		}
+	}
 
-  if token_parts[0] != "v2" || token_parts[1] != "local" {
-    return Err(GenericError::InvalidToken {})?;
-  }
+	if token_parts[0] != "v2" || token_parts[1] != "local" {
+		return Err(GenericError::InvalidToken {}.into());
+	}
 
-  let mut decoded = decode_config(token_parts[2].as_bytes(), URL_SAFE_NO_PAD)?;
-  let (nonce, ciphertext) = decoded.split_at_mut(24);
+	let mut decoded = decode_config(token_parts[2].as_bytes(), URL_SAFE_NO_PAD)
+		.map_err(|e| PasetoError::GenericError(GenericError::Base64Error(e)))?;
+	let (nonce, ciphertext) = decoded.split_at_mut(24);
 
-  let pre_auth = pae(&[HEADER.as_bytes(), nonce, footer_str.as_bytes()]);
+	let pre_auth = pae(&[HEADER.as_bytes(), nonce, footer_str.as_bytes()]);
 
-  let nonce_obj = XNonce::from_slice(nonce);
-  let aead = XChaCha20Poly1305::new_from_slice(key);
-  if aead.is_err() {
-    return Err(SodiumErrors::InvalidKey {})?;
-  }
-  let aead = aead.unwrap();
-  let decrypted = aead.decrypt(
-    nonce_obj,
-    Payload {
-      msg: ciphertext,
-      aad: &pre_auth,
-    },
-  );
-  if decrypted.is_err() {
-    return Err(SodiumErrors::FunctionError {})?;
-  }
+	let nonce_obj = XNonce::from_slice(nonce);
+	let aead = XChaCha20Poly1305::new_from_slice(key)
+		.map_err(|_| PasetoError::LibsodiumError(SodiumErrors::InvalidKey {}))?;
 
-  Ok(String::from_utf8(decrypted.unwrap())?)
+	match aead.decrypt(
+		nonce_obj,
+		Payload {
+			msg: ciphertext,
+			aad: &pre_auth,
+		},
+	) {
+		Ok(decrypted) => String::from_utf8(decrypted)
+			.map_err(|e| PasetoError::GenericError(GenericError::Utf8Error(e))),
+		Err(_) => Err(SodiumErrors::FunctionError {}.into()),
+	}
 }
 
 #[cfg(test)]
 mod unit_tests {
-  use super::*;
+	use super::*;
 
-  #[test]
-  fn paseto_empty_encrypt_verify() {
-    let empty_key = [0; 32];
-    let full_key = [255; 32];
-    let result = underlying_local_paseto("", None, &[0; 24], &empty_key);
-    if result.is_err() {
-      println!("Failed to encrypt Paseto!");
-      println!("{:?}", result);
-      panic!("Paseto Failure Encryption!");
-    }
-    let the_str = result.unwrap();
+	#[test]
+	fn paseto_empty_encrypt_verify() {
+		let empty_key = [0; 32];
+		let full_key = [255; 32];
+		let result = underlying_local_paseto("", None, &[0; 24], &empty_key);
+		if result.is_err() {
+			println!("Failed to encrypt Paseto!");
+			println!("{:?}", result);
+			panic!("Paseto Failure Encryption!");
+		}
+		let the_str = result.unwrap();
 
-    assert_eq!(
-      "v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNUtKpdy5KXjKfpSKrOlqQvQ",
-      the_str
-    );
+		assert_eq!(
+			"v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNUtKpdy5KXjKfpSKrOlqQvQ",
+			the_str
+		);
 
-    let result_full = underlying_local_paseto("", None, &[0; 24], &full_key);
-    if result_full.is_err() {
-      println!("Failed to encrypt Paseto!");
-      println!("{:?}", result_full);
-      panic!("Paseto Failure Encryption!");
-    }
-    let the_full_str = result_full.unwrap();
+		let result_full = underlying_local_paseto("", None, &[0; 24], &full_key);
+		if result_full.is_err() {
+			println!("Failed to encrypt Paseto!");
+			println!("{:?}", result_full);
+			panic!("Paseto Failure Encryption!");
+		}
+		let the_full_str = result_full.unwrap();
 
-    assert_eq!(
-      "v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNSOvpveyCsjPYfe9mtiJDVg",
-      the_full_str
-    );
-  }
+		assert_eq!(
+			"v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNSOvpveyCsjPYfe9mtiJDVg",
+			the_full_str
+		);
+	}
 
-  #[test]
-  fn paseto_non_empty_footer_encrypt_verify() {
-    let empty_key = [0; 32];
-    let full_key = [255; 32];
+	#[test]
+	fn paseto_non_empty_footer_encrypt_verify() {
+		let empty_key = [0; 32];
+		let full_key = [255; 32];
 
-    let result = underlying_local_paseto("", Some("Cuon Alpinus"), &[0; 24], &empty_key);
-    if result.is_err() {
-      println!("Failed to encrypt Paseto!");
-      println!("{:?}", result);
-      panic!("Paseto Failure Encryption!");
-    }
-    let the_str = result.unwrap();
+		let result = underlying_local_paseto("", Some("Cuon Alpinus"), &[0; 24], &empty_key);
+		if result.is_err() {
+			println!("Failed to encrypt Paseto!");
+			println!("{:?}", result);
+			panic!("Paseto Failure Encryption!");
+		}
+		let the_str = result.unwrap();
 
-    assert_eq!(
-      "v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNfzz6yGkE4ZxojJAJwKLfvg.Q3VvbiBBbHBpbnVz",
-      the_str
-    );
+		assert_eq!(
+			"v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNfzz6yGkE4ZxojJAJwKLfvg.Q3VvbiBBbHBpbnVz",
+			the_str
+		);
 
-    let full_result = underlying_local_paseto("", Some("Cuon Alpinus"), &[0; 24], &full_key);
-    if full_result.is_err() {
-      println!("Failed to encrypt Paseto!");
-      println!("{:?}", full_result);
-      panic!("Paseto Failure Encryption!");
-    }
-    let full_str = full_result.unwrap();
+		let full_result = underlying_local_paseto("", Some("Cuon Alpinus"), &[0; 24], &full_key);
+		if full_result.is_err() {
+			println!("Failed to encrypt Paseto!");
+			println!("{:?}", full_result);
+			panic!("Paseto Failure Encryption!");
+		}
+		let full_str = full_result.unwrap();
 
-    assert_eq!(
-      "v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNJbTJxAGtEg4ZMXY9g2LSoQ.Q3VvbiBBbHBpbnVz",
-      full_str
-    );
-  }
+		assert_eq!(
+			"v2.local.driRNhM20GQPvlWfJCepzh6HdijAq-yNJbTJxAGtEg4ZMXY9g2LSoQ.Q3VvbiBBbHBpbnVz",
+			full_str
+		);
+	}
 
-  #[test]
-  fn paseto_non_empty_msg_encrypt_verify() {
-    let empty_key = [0; 32];
-    let full_key = [255; 32];
+	#[test]
+	fn paseto_non_empty_msg_encrypt_verify() {
+		let empty_key = [0; 32];
+		let full_key = [255; 32];
 
-    let result = underlying_local_paseto("Love is stronger than hate or fear", None, &[0; 24], &empty_key);
-    if result.is_err() {
-      println!("Failed to encrypt Paseto!");
-      println!("{:?}", result);
-      panic!("Paseto Failure Encryption!");
-    }
-    let the_str = result.unwrap();
+		let result = underlying_local_paseto(
+			"Love is stronger than hate or fear",
+			None,
+			&[0; 24],
+			&empty_key,
+		);
+		if result.is_err() {
+			println!("Failed to encrypt Paseto!");
+			println!("{:?}", result);
+			panic!("Paseto Failure Encryption!");
+		}
+		let the_str = result.unwrap();
 
-    assert_eq!(
+		assert_eq!(
       "v2.local.BEsKs5AolRYDb_O-bO-lwHWUextpShFSvu6cB-KuR4wR9uDMjd45cPiOF0zxb7rrtOB5tRcS7dWsFwY4ONEuL5sWeunqHC9jxU0",
       the_str
     );
 
-    let full_result = underlying_local_paseto("Love is stronger than hate or fear", None, &[0; 24], &full_key);
-    if full_result.is_err() {
-      println!("Failed to encrypt Paseto!");
-      println!("{:?}", full_result);
-      panic!("Paseto Failure Encryption!");
-    }
+		let full_result = underlying_local_paseto(
+			"Love is stronger than hate or fear",
+			None,
+			&[0; 24],
+			&full_key,
+		);
+		if full_result.is_err() {
+			println!("Failed to encrypt Paseto!");
+			println!("{:?}", full_result);
+			panic!("Paseto Failure Encryption!");
+		}
 
-    let full_str = full_result.unwrap();
+		let full_str = full_result.unwrap();
 
-    assert_eq!(
+		assert_eq!(
       "v2.local.BEsKs5AolRYDb_O-bO-lwHWUextpShFSjvSia2-chHyMi4LtHA8yFr1V7iZmKBWqzg5geEyNAAaD6xSEfxoET1xXqahe1jqmmPw",
       full_str
     );
-  }
+	}
 
-  #[test]
-  fn full_round_paseto() {
-    let empty_key = [0; 32];
+	#[test]
+	fn full_round_paseto() {
+		let empty_key = [0; 32];
 
-    let result = local_paseto("Love is stronger than hate or fear", Some("gwiz-bot"), &empty_key);
-    if result.is_err() {
-      println!("Failed to encrypt Paseto!");
-      println!("{:?}", result);
-      panic!("Paseto Failure Encryption!");
-    }
-    let the_str = result.unwrap();
+		let result = local_paseto(
+			"Love is stronger than hate or fear",
+			Some("gwiz-bot"),
+			&empty_key,
+		);
+		if result.is_err() {
+			println!("Failed to encrypt Paseto!");
+			println!("{:?}", result);
+			panic!("Paseto Failure Encryption!");
+		}
+		let the_str = result.unwrap();
 
-    println!("Paseto Full Round Token: [ {:?} ]", the_str);
+		println!("Paseto Full Round Token: [ {:?} ]", the_str);
 
-    let decrypted_result = decrypt_paseto(&the_str, Some("gwiz-bot"), &empty_key);
-    if decrypted_result.is_err() {
-      println!("Failed to decrypt Paseto!");
-      println!("{:?}", decrypted_result);
-      panic!("Paseto Failure Decryption!");
-    }
-    let decrypted = decrypted_result.unwrap();
+		let decrypted_result = decrypt_paseto(&the_str, Some("gwiz-bot"), &empty_key);
+		if decrypted_result.is_err() {
+			println!("Failed to decrypt Paseto!");
+			println!("{:?}", decrypted_result);
+			panic!("Paseto Failure Decryption!");
+		}
+		let decrypted = decrypted_result.unwrap();
 
-    assert_eq!(decrypted, "Love is stronger than hate or fear");
-  }
+		assert_eq!(decrypted, "Love is stronger than hate or fear");
+	}
 }

--- a/src/v2/public.rs
+++ b/src/v2/public.rs
@@ -1,11 +1,12 @@
 //! An implementation of Paseto v2 "public" tokens, or tokens that
 //! are signed with a public/private key pair.
 
-use crate::errors::GenericError;
-use crate::pae::pae;
+use crate::{
+	errors::{GenericError, PasetoError},
+	pae::pae,
+};
 
 use base64::{decode_config, encode_config, URL_SAFE_NO_PAD};
-use failure::Error;
 use ring::constant_time::verify_slices_are_equal as ConstantTimeEquals;
 use ring::signature::{Ed25519KeyPair, UnparsedPublicKey, ED25519};
 
@@ -14,145 +15,187 @@ const HEADER: &str = "v2.public.";
 /// Sign a "v2.public" paseto token.
 ///
 /// Returns a result of a string if signing was successful.
-pub fn public_paseto(msg: &str, footer: Option<&str>, key_pair: &Ed25519KeyPair) -> Result<String, Error> {
-  let footer_frd = footer.unwrap_or("");
+///
+/// # Errors
+///
+/// If there was a failure signing the data.
+pub fn public_paseto(
+	msg: &str,
+	footer: Option<&str>,
+	key_pair: &Ed25519KeyPair,
+) -> Result<String, PasetoError> {
+	let footer_frd = footer.unwrap_or("");
 
-  let pre_auth = pae(&[HEADER.as_bytes(), msg.as_bytes(), footer_frd.as_bytes()]);
+	let pre_auth = pae(&[HEADER.as_bytes(), msg.as_bytes(), footer_frd.as_bytes()]);
 
-  let sig = key_pair.sign(&pre_auth);
-  let mut m_and_sig = Vec::from(msg.as_bytes());
-  m_and_sig.extend_from_slice(sig.as_ref());
+	let sig = key_pair.sign(&pre_auth);
+	let mut m_and_sig = Vec::from(msg.as_bytes());
+	m_and_sig.extend_from_slice(sig.as_ref());
 
-  let token = if footer_frd.is_empty() {
-    format!("{}{}", HEADER, encode_config(&m_and_sig, URL_SAFE_NO_PAD))
-  } else {
-    format!(
-      "{}{}.{}",
-      HEADER,
-      encode_config(&m_and_sig, URL_SAFE_NO_PAD),
-      encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
-    )
-  };
+	let token = if footer_frd.is_empty() {
+		format!("{}{}", HEADER, encode_config(&m_and_sig, URL_SAFE_NO_PAD))
+	} else {
+		format!(
+			"{}{}.{}",
+			HEADER,
+			encode_config(&m_and_sig, URL_SAFE_NO_PAD),
+			encode_config(footer_frd.as_bytes(), URL_SAFE_NO_PAD)
+		)
+	};
 
-  Ok(token)
+	Ok(token)
 }
 
 /// Verifies a "v2.public" paseto token based on a given key pair.
 ///
-/// Returns the message if verification was successful, otherwise an Err().
-pub fn verify_paseto(token: &str, footer: Option<&str>, public_key: &[u8]) -> Result<String, Error> {
-  let token_parts = token.split(".").collect::<Vec<_>>();
-  if token_parts.len() < 3 {
-    return Err(GenericError::InvalidToken {})?;
-  }
+/// Returns the message if verification was successful.
+///
+/// # Errors
+///
+/// If the string passed in was not a valid token, and did not have a correct footer.
+pub fn verify_paseto(
+	token: &str,
+	footer: Option<&str>,
+	public_key: &[u8],
+) -> Result<String, PasetoError> {
+	let token_parts = token.split('.').collect::<Vec<_>>();
+	if token_parts.len() < 3 {
+		return Err(PasetoError::GenericError(GenericError::InvalidToken {}));
+	}
 
-  let has_provided_footer = footer.is_some();
-  let footer_as_str = footer.unwrap_or("");
+	let has_provided_footer = footer.is_some();
+	let footer_as_str = footer.unwrap_or("");
 
-  if has_provided_footer {
-    if token_parts.len() < 4 {
-      return Err(GenericError::InvalidFooter {})?;
-    }
-    let footer_encoded = encode_config(footer_as_str.as_bytes(), URL_SAFE_NO_PAD);
+	if has_provided_footer {
+		if token_parts.len() < 4 {
+			return Err(PasetoError::GenericError(GenericError::InvalidFooter {}));
+		}
+		let footer_encoded = encode_config(footer_as_str.as_bytes(), URL_SAFE_NO_PAD);
 
-    if ConstantTimeEquals(footer_encoded.as_bytes(), token_parts[3].as_bytes()).is_err() {
-      return Err(GenericError::InvalidFooter {})?;
-    }
-  }
+		if ConstantTimeEquals(footer_encoded.as_bytes(), token_parts[3].as_bytes()).is_err() {
+			return Err(PasetoError::GenericError(GenericError::InvalidFooter {}));
+		}
+	}
 
-  if token_parts[0] != "v2" || token_parts[1] != "public" {
-    return Err(GenericError::InvalidToken {})?;
-  }
+	if token_parts[0] != "v2" || token_parts[1] != "public" {
+		return Err(PasetoError::GenericError(GenericError::InvalidToken {}));
+	}
 
-  let decoded = decode_config(token_parts[2].as_bytes(), URL_SAFE_NO_PAD)?;
-  let decoded_len = decoded.len();
-  let (msg, sig) = decoded.split_at(decoded_len - 64);
+	let decoded = decode_config(token_parts[2].as_bytes(), URL_SAFE_NO_PAD)
+		.map_err(|e| PasetoError::GenericError(GenericError::Base64Error(e)))?;
+	let decoded_len = decoded.len();
+	let (msg, sig) = decoded.split_at(decoded_len - 64);
 
-  let pre_auth = pae(&[HEADER.as_bytes(), msg, footer_as_str.as_bytes()]);
+	let pre_auth = pae(&[HEADER.as_bytes(), msg, footer_as_str.as_bytes()]);
 
-  let pk_unparsed = UnparsedPublicKey::new(&ED25519, public_key);
-  let verify_res = pk_unparsed.verify(&pre_auth, sig);
-  if verify_res.is_err() {
-    return Err(GenericError::InvalidToken {})?;
-  }
+	let pk_unparsed = UnparsedPublicKey::new(&ED25519, public_key);
+	let verify_res = pk_unparsed.verify(&pre_auth, sig);
+	if verify_res.is_err() {
+		return Err(PasetoError::GenericError(GenericError::InvalidToken {}));
+	}
 
-  Ok(String::from_utf8(Vec::from(msg))?)
+	String::from_utf8(Vec::from(msg))
+		.map_err(|e| PasetoError::GenericError(GenericError::Utf8Error(e)))
 }
 
 #[cfg(test)]
 mod unit_tests {
-  use super::*;
+	use super::*;
 
-  use ring::rand::SystemRandom;
-  use ring::signature::KeyPair;
+	use ring::rand::SystemRandom;
+	use ring::signature::KeyPair;
 
-  #[test]
-  fn paseto_public_verify() {
-    let sys_rand = SystemRandom::new();
-    let key_pkcs8 = Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
-    let as_key = Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
+	#[test]
+	fn paseto_public_verify() {
+		let sys_rand = SystemRandom::new();
+		let key_pkcs8 =
+			Ed25519KeyPair::generate_pkcs8(&sys_rand).expect("Failed to generate pkcs8 key!");
+		let as_key =
+			Ed25519KeyPair::from_pkcs8(key_pkcs8.as_ref()).expect("Failed to parse keypair");
 
-    // Test messages without footers.
-    let public_token_one = public_paseto("msg", None, &as_key).expect("Failed to public encode msg with no footer!");
-    // NOTE: This test is just ensuring we can encode a json object, remember these internal impls
-    // don't check for expires being valid!
-    let public_token_two = public_paseto(
-      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
-      None,
-      &as_key,
-    )
-    .expect("Failed to public encode json blob with no footer!");
+		// Test messages without footers.
+		let public_token_one = public_paseto("msg", None, &as_key)
+			.expect("Failed to public encode msg with no footer!");
+		// NOTE: This test is just ensuring we can encode a json object, remember these internal impls
+		// don't check for expires being valid!
+		let public_token_two = public_paseto(
+			"{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
+			None,
+			&as_key,
+		)
+		.expect("Failed to public encode json blob with no footer!");
 
-    assert!(public_token_one.starts_with("v2.public."));
-    assert!(public_token_two.starts_with("v2.public."));
+		assert!(public_token_one.starts_with("v2.public."));
+		assert!(public_token_two.starts_with("v2.public."));
 
-    let verified_one = verify_paseto(&public_token_one.clone(), None, as_key.public_key().as_ref());
-    let verified_two = verify_paseto(&public_token_two, None, as_key.public_key().as_ref());
+		let verified_one = verify_paseto(
+			&public_token_one.clone(),
+			None,
+			as_key.public_key().as_ref(),
+		);
+		let verified_two = verify_paseto(&public_token_two, None, as_key.public_key().as_ref());
 
-    // Verify the above tokens.
-    assert!(verified_one.is_ok());
-    assert!(verified_two.is_ok());
-    assert_eq!(verified_one.unwrap(), "msg");
-    assert_eq!(
-      verified_two.unwrap(),
-      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"
-    );
+		// Verify the above tokens.
+		assert!(verified_one.is_ok());
+		assert!(verified_two.is_ok());
+		assert_eq!(verified_one.unwrap(), "msg");
+		assert_eq!(
+			verified_two.unwrap(),
+			"{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"
+		);
 
-    let should_not_verify_one = verify_paseto(&public_token_one, Some("data"), as_key.public_key().as_ref());
+		let should_not_verify_one = verify_paseto(
+			&public_token_one,
+			Some("data"),
+			as_key.public_key().as_ref(),
+		);
 
-    // Verify if it doesn't have a footer in public that it won't pass a verification with a footer.
-    assert!(should_not_verify_one.is_err());
+		// Verify if it doesn't have a footer in public that it won't pass a verification with a footer.
+		assert!(should_not_verify_one.is_err());
 
-    // Now lets verify with footers.
-    let public_token_three =
-      public_paseto("msg", Some("footer"), &as_key).expect("Failed to public encode msg with footer!");
-    let public_token_four = public_paseto(
-      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
-      Some("footer"),
-      &as_key,
-    )
-    .expect("Failed to public encode json blob with footer!");
+		// Now lets verify with footers.
+		let public_token_three = public_paseto("msg", Some("footer"), &as_key)
+			.expect("Failed to public encode msg with footer!");
+		let public_token_four = public_paseto(
+			"{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}",
+			Some("footer"),
+			&as_key,
+		)
+		.expect("Failed to public encode json blob with footer!");
 
-    assert!(public_token_three.starts_with("v2.public."));
-    assert!(public_token_four.starts_with("v2.public."));
+		assert!(public_token_three.starts_with("v2.public."));
+		assert!(public_token_four.starts_with("v2.public."));
 
-    let verified_three = verify_paseto(&public_token_three, Some("footer"), as_key.public_key().as_ref());
-    let verified_four = verify_paseto(&public_token_four, Some("footer"), as_key.public_key().as_ref());
+		let verified_three = verify_paseto(
+			&public_token_three,
+			Some("footer"),
+			as_key.public_key().as_ref(),
+		);
+		let verified_four = verify_paseto(
+			&public_token_four,
+			Some("footer"),
+			as_key.public_key().as_ref(),
+		);
 
-    // Verify the footer tokens.
-    assert!(verified_three.is_ok());
-    assert!(verified_four.is_ok());
-    assert_eq!(verified_three.unwrap(), "msg");
-    assert_eq!(
-      verified_four.unwrap(),
-      "{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"
-    );
+		// Verify the footer tokens.
+		assert!(verified_three.is_ok());
+		assert!(verified_four.is_ok());
+		assert_eq!(verified_three.unwrap(), "msg");
+		assert_eq!(
+			verified_four.unwrap(),
+			"{\"data\": \"yo bro\", \"expires\": \"2018-01-01T00:00:00+00:00\"}"
+		);
 
-    // Validate no footer + invalid footer both fail on tokens encode with footer.
-    let should_not_verify_two = verify_paseto(&public_token_three, None, as_key.public_key().as_ref());
-    let should_not_verify_three = verify_paseto(&public_token_three, Some("bleh"), as_key.public_key().as_ref());
+		// Validate no footer + invalid footer both fail on tokens encode with footer.
+		let should_not_verify_two =
+			verify_paseto(&public_token_three, None, as_key.public_key().as_ref());
+		let should_not_verify_three = verify_paseto(
+			&public_token_three,
+			Some("bleh"),
+			as_key.public_key().as_ref(),
+		);
 
-    assert!(should_not_verify_two.is_err());
-    assert!(should_not_verify_three.is_err());
-  }
+		assert!(should_not_verify_two.is_err());
+		assert!(should_not_verify_three.is_err());
+	}
 }


### PR DESCRIPTION
Change-Id: fd605213d2008a85be46aeca9776a404caf5b33f

## Motivation (required) ##

- Move to thiserror over failure, as it's much more popular in the community, and has proper maintenance, support, and all around a better base to build off of. I was hesitant in the past for breaking changes, but since we're making breaking changes for v3/v4 anyway this is fine.
- Start linting with clippy to catch a lot of bad patterns we had.
- Update formatting rules, my editor has had some regressions in the past where with my screenreader it reads out every space, tabs prevent this from happening ever, and local editors can be configured for display.

## Test Plan (required) ##

- All tests, along with the new clippy ci lint rule should continue to pass.
